### PR TITLE
Simple table support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ _italic_
 ```
 * Tables (with simple text content only)
 ```
-cols="3*", options="header"]
+[cols="3*", options="header"]
 |===
 | A
 | B

--- a/README.md
+++ b/README.md
@@ -77,4 +77,5 @@ cols="3*", options="header"]
 | Green
 | Blue
 | Red
+|===
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 * Add some reporting service to print out result
 * Page content comparison is not working and therefore new versions are always created
 * Link between pages
-* Tables
+* Rich content in tables
 * Info/error/warning blocks
 * Bullet and numbered lists
 
@@ -61,4 +61,20 @@ image::sunset.jpg[height="100",width="200",link="http://website.com"]
 * Italic text
 ```
 _italic_
+```
+* Tables (with simple text content only)
+```
+cols="3*", options="header"]
+|===
+| A
+| B
+| C
+
+| 10
+| 20
+| 30
+
+| Green
+| Blue
+| Red
 ```

--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_table.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_table.html.slim
@@ -1,0 +1,8 @@
+table
+  - [:head, :foot, :body].select {|tblsec| !@rows[tblsec].empty? }.each do |tblsec|
+    *{:tag=>"t#{tblsec}"}
+      - @rows[tblsec].each do |row|
+        tr
+          - row.each do |cell|
+            *{:tag=>(tblsec == :head ? 'th' : 'td')}
+              =cell.text

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -212,7 +212,8 @@ public class AsciidocConfluencePageTest {
                 "\n" +
                 "| 20\n" +
                 "| 21\n" +
-                "| 22";
+                "| 22\n" +
+                "|===";
         InputStream is = stringAsInputStream(adocContent);
 
         // act
@@ -239,7 +240,8 @@ public class AsciidocConfluencePageTest {
                 "\n" +
                 "| 20\n" +
                 "| 21\n" +
-                "| 22";
+                "| 22\n" +
+                "|===";
         InputStream is = stringAsInputStream(adocContent);
 
         // act

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -197,6 +197,60 @@ public class AsciidocConfluencePageTest {
     }
 
     @Test
+    public void renderConfluencePage_asciiDocWithoutTableWithHeader_returnsConfluencePageContentWithTableWithoutHeader() throws Exception {
+        // arrange
+        String adocContent = "" +
+                "[cols=\"3*\"]\n" +
+                "|===\n" +
+                "| A\n" +
+                "| B\n" +
+                "| C\n" +
+                "\n" +
+                "| 10\n" +
+                "| 11\n" +
+                "| 12\n" +
+                "\n" +
+                "| 20\n" +
+                "| 21\n" +
+                "| 22";
+        InputStream is = stringAsInputStream(adocContent);
+
+        // act
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(is, TEMPLATES_DIR);
+
+        // assert
+        String expectedContent ="<table><tbody><tr><td>A</td><td>B</td><td>C</td></tr><tr><td>10</td><td>11</td><td>12</td></tr><tr><td>20</td><td>21</td><td>22</td></tr></tbody></table>";
+        assertThat(asciidocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
+    public void renderConfluencePage_asciiDocWithTableWithHeader_returnsConfluencePageContentWithTableWithHeader() throws Exception {
+        // arrange
+        String adocContent = "" +
+                "[cols=\"3*\", options=\"header\"]\n" +
+                "|===\n" +
+                "| A\n" +
+                "| B\n" +
+                "| C\n" +
+                "\n" +
+                "| 10\n" +
+                "| 11\n" +
+                "| 12\n" +
+                "\n" +
+                "| 20\n" +
+                "| 21\n" +
+                "| 22";
+        InputStream is = stringAsInputStream(adocContent);
+
+        // act
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(is, TEMPLATES_DIR);
+
+        // assert
+        String expectedContent ="<table><thead><tr><th>A</th><th>B</th><th>C</th></tr></thead><tbody><tr><td>10</td><td>11</td><td>12</td></tr><tr><td>20</td><td>21</td><td>22</td></tr></tbody></table>";
+        assertThat(asciidocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
     public void images_asciiDocwithImage_returnsFilePathToImage() throws Exception {
         // arrange
         String adocContent = "image::sunset.jpg[]";

--- a/asciidoc-confluence-publisher-maven-plugin-sample/doc/index.adoc
+++ b/asciidoc-confluence-publisher-maven-plugin-sample/doc/index.adoc
@@ -26,3 +26,20 @@ import java.util.List;
 == Nice plane on carpet
 
 image::plane.jpg[width="300"]
+
+== Simple table
+
+[cols="3*", options="header"]
+|===
+| A
+| B
+| C
+
+| 10
+| 20
+| 30
+
+| Green
+| Blue
+| Red
+|===

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
             <dependency>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctorj</artifactId>
-                <version>1.5.3.2</version>
+                <version>1.5.4.1</version>
                 <scope>compile</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Supports tables with and without header and simple text content.

Required upgrade to AsciiDoctorJ 1.5.4.1.