### PR TITLE
Bullet and numbered lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 * Internal cross references
 * Links to attachments
 * Rich content in tables
-* Bullet and numbered lists
 
 ## Supported Asciidoc Elements
 
@@ -29,6 +28,24 @@
 Paragraph 1
 
 Paragraph 2
+```
+* Unordered Lists
+```
+* Level 1
+** Level 2
+*** Level 3
+**** Level 4
+***** Level 5
+* Level 1
+```
+* Ordered Lists
+```
+. Level 1
+.. Level 2
+... Level 3
+.... Level 4
+..... Level 5
+. Level 1
 ```
 * Listings
 ```

--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_olist.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_olist.html.slim
@@ -1,0 +1,6 @@
+ol
+  - items.each do |item|
+    li
+      =item.text
+      - if item.blocks?
+        =item.content

--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_ulist.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_ulist.html.slim
@@ -1,0 +1,6 @@
+ul
+  - items.each do |item|
+    li
+      =item.text
+      - if item.blocks?
+        =item.content

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -644,7 +644,7 @@ public class AsciidocConfluencePageTest {
     }
 
     @Test
-    public void renderConfluencePage_asciiDocWithUnorderedList_returnsConfluencePageHavingCorrectListMarkup() {
+    public void renderConfluencePage_asciiDocWithUnorderedList_returnsConfluencePageHavingCorrectUnorderedListMarkup() {
         // arrange
         String adocContent = "* L1-1\n" +
                 "** L2-1\n" +
@@ -659,6 +659,25 @@ public class AsciidocConfluencePageTest {
 
         // assert
         String expectedContent = "<ul><li>L1-1<ul><li>L2-1<ul><li>L3-1<ul><li>L4-1<ul><li>L5-1</li></ul></li></ul></li></ul></li></ul></li><li>L1-2</li></ul>";
+        assertThat(asciidocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
+    public void renderConfluencePage_asciiDocWithOrderedList_returnsConfluencePageHavingCorrectOrderedListMarkup() {
+        // arrange
+        String adocContent = ". L1-1\n" +
+                ".. L2-1\n" +
+                "... L3-1\n" +
+                ".... L4-1\n" +
+                "..... L5-1\n" +
+                ". L1-2";
+        InputStream is = stringAsInputStream(prependTitle(adocContent));
+
+        // act
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(is, TEMPLATES_DIR, dummyOutputPath(), dummyPagePath());
+
+        // assert
+        String expectedContent = "<ol><li>L1-1<ol><li>L2-1<ol><li>L3-1<ol><li>L4-1<ol><li>L5-1</li></ol></li></ol></li></ol></li></ol></li><li>L1-2</li></ol>";
         assertThat(asciidocConfluencePage.content(), is(expectedContent));
     }
 

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -644,6 +644,25 @@ public class AsciidocConfluencePageTest {
     }
 
     @Test
+    public void renderConfluencePage_asciiDocWithUnorderedList_returnsConfluencePageHavingCorrectListMarkup() {
+        // arrange
+        String adocContent = "* L1-1\n" +
+                "** L2-1\n" +
+                "*** L3-1\n" +
+                "**** L4-1\n" +
+                "***** L5-1\n" +
+                "* L1-2";
+        InputStream is = stringAsInputStream(prependTitle(adocContent));
+
+        // act
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(is, TEMPLATES_DIR, dummyOutputPath(), dummyPagePath());
+
+        // assert
+        String expectedContent = "<ul><li>L1-1<ul><li>L2-1<ul><li>L3-1<ul><li>L4-1<ul><li>L5-1</li></ul></li></ul></li></ul></li></ul></li><li>L1-2</li></ul>";
+        assertThat(asciidocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
     public void attachments_asciiDocWithImage_returnsImageAsAttachmentWithPathAndName() throws Exception {
         // arrange
         String adocContent = "image::sunset.jpg[]";

--- a/asciidoc-confluence-publisher-maven-plugin-sample/doc/index.adoc
+++ b/asciidoc-confluence-publisher-maven-plugin-sample/doc/index.adoc
@@ -37,6 +37,26 @@ import java.util.List;
 image::img/rc-model-plane.jpg[width="300"]
 image::frisbee.png[width="300"]
 
+== Lists
+
+unordered:
+
+* Level 1
+** Level 2
+*** Level 3
+**** Level 4
+***** Level 5
+* Level 1
+
+ordered:
+
+. Level 1
+.. Level 2
+... Level 3
+.... Level 4
+..... Level 5
+. Level 1
+
 == Simple table
 
 [cols="3*", options="header"]


### PR DESCRIPTION
- support for bullet (unordered) lists up to 5 levels
- support for numbered (ordered) lists up to 5 levels

*To Discuss*
- should asciidoc checkbox lists be supported and mapped to confluence `ac:task` element?