### PR TITLE
Fix embedded plantuml diagrams in nested pages

### DIFF
--- a/asciidoc-confluence-publisher-converter/src/main/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePage.java
+++ b/asciidoc-confluence-publisher-converter/src/main/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePage.java
@@ -76,12 +76,12 @@ public class AsciidocConfluencePage {
         return unmodifiableMap(this.attachments);
     }
 
-    public static AsciidocConfluencePage newAsciidocConfluencePage(InputStream adoc, String templatesDir, String generatedDocOutputPath, Path pagePath) {
+    public static AsciidocConfluencePage newAsciidocConfluencePage(InputStream adoc, String templatesDir, String imagesOutDir, Path pagePath) {
         Map<String, String> attachmentCollector = new HashMap<>();
 
         String adocContent = IOUtils.readFull(adoc);
 
-        Options options = options(templatesDir, parentFolder(pagePath), generatedDocOutputPath);
+        Options options = options(templatesDir, parentFolder(pagePath), imagesOutDir);
         String pageContent = convertedContent(adocContent, options, pagePath, attachmentCollector);
 
         String pageTitle = pageTitle(adocContent);

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -23,6 +23,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -662,13 +663,15 @@ public class AsciidocConfluencePageTest {
                 "....";
 
         InputStream is = stringAsInputStream(prependTitle(adocContent));
+        String imagesOutDirectory = dummyOutputPath();
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(is, TEMPLATES_DIR, dummyOutputPath(), dummyPagePath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(is, TEMPLATES_DIR, imagesOutDirectory, dummyPagePath());
 
         // assert
         String expectedContent = "<ac:image ac:height=\"175\" ac:width=\"57\"><ri:attachment ri:filename=\"embedded-diagram.png\"></ri:attachment></ac:image>";
         assertThat(asciidocConfluencePage.content(), containsString(expectedContent));
+        assertThat(new File(imagesOutDirectory, "embedded-diagram.png").exists(), is(true));
     }
 
     @Test

--- a/asciidoc-confluence-publisher-maven-plugin/src/main/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/AsciidocConfluenceConverter.java
+++ b/asciidoc-confluence-publisher-maven-plugin/src/main/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/AsciidocConfluenceConverter.java
@@ -118,6 +118,7 @@ final class AsciidocConfluenceConverter {
             String absolutePath = file.toFile().getAbsolutePath();
             String relativePath = absolutePath.substring(this.asciidocRootFolder.length() + 1);
             File targetFile = new File(this.generatedDocOutputPath, relativePath);
+            String imagesOutDir = targetFile.getParent();
 
             createMissingDirectories(targetFile);
 
@@ -125,7 +126,7 @@ final class AsciidocConfluenceConverter {
                 if (isAdocFile(file)) {
                     File confluenceHtmlOutputFile = replaceFileExtension(targetFile, "html");
                     confluenceHtmlOutputFile.createNewFile();
-                    AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(Files.newInputStream(file), this.asciidocConfluenceTemplatesPath, this.generatedDocOutputPath, file);
+                    AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(Files.newInputStream(file), this.asciidocConfluenceTemplatesPath, imagesOutDir, file);
                     write(asciidocConfluencePage.content(), new FileOutputStream(confluenceHtmlOutputFile), "UTF-8");
 
                     ConfluencePageMetadata confluencePageMetadata = new ConfluencePageMetadata();

--- a/asciidoc-confluence-publisher-maven-plugin/src/test/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/AsciidocConfluenceConverterTest.java
+++ b/asciidoc-confluence-publisher-maven-plugin/src/test/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/AsciidocConfluenceConverterTest.java
@@ -57,5 +57,6 @@ public class AsciidocConfluenceConverterTest {
         assertThat("index/sub-page.html", Files.exists(Paths.get(generatedDocOutputPath, "index", "sub-page.html")), is(true));
         assertThat("index/sub-page/", Files.exists(Paths.get(generatedDocOutputPath, "index", "sub-page")), is(true));
         assertThat("index/sub-page/sub-sub-page.html", Files.exists(Paths.get(generatedDocOutputPath, "index", "sub-page", "sub-sub-page.html")), is(true));
+        assertThat("index/embedded-diagram.png", Files.exists(Paths.get(generatedDocOutputPath, "index", "embedded-diagram.png")), is(true));
     }
 }

--- a/asciidoc-confluence-publisher-maven-plugin/src/test/resources/org/sahli/asciidoc/confluence/publisher/maven/plugin/doc/index/sub-page.adoc
+++ b/asciidoc-confluence-publisher-maven-plugin/src/test/resources/org/sahli/asciidoc/confluence/publisher/maven/plugin/doc/index/sub-page.adoc
@@ -26,3 +26,11 @@ import java.util.List;
 ====
 Some note
 ====
+
+[plantuml, embedded-diagram, png]
+....
+class A
+class B
+
+A <|-- B
+....


### PR DESCRIPTION
* fixed converter to pass in parent directory of asciidoc file (not generated output root path) as images output directory