### PR TITLE
Fix Failed Builds on Travis Trusty Build Environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+group: deprecated-2017Q2
 
 services:
   - docker


### PR DESCRIPTION
- temporarily configure previous (non-trusty) build environment
- see https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch