### PR TITLE
Disable integration tests for pull request builds from forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,12 @@ before_script:
 script:
   - if [ -n "$TRAVIS_TAG" ]; then ./mvnw versions:set -DnewVersion=$TRAVIS_TAG -nsu; fi
   - ./mvnw clean install jacoco:report coveralls:report -nsu
-  - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
-  - docker run -d -p8090:8090 -p8091:8091 --name=confluence-publisher-it alainsahli/confluence-publisher-it:6.0.5
-  - ./waitForConfluenceStartup.sh confluence-publisher-it 300
-  - ./mvnw -Pintegration-tests failsafe:integration-test failsafe:verify -nsu
-  - ./mvnw -pl asciidoc-confluence-publisher-doc asciidoc-confluence-publisher:publish -nsu
-  - if ( [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] ) || [ -n "$TRAVIS_TAG" ]; then ./importGpgKey.sh; ./mvnw -X -s .settings.xml jar:jar source:jar javadoc:jar gpg:sign nexus-staging:deploy -Possrh -nsu; fi
+  - if ( [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] ); then docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD; fi
+  - if ( [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] ); then docker run -d -p8090:8090 -p8091:8091 --name=confluence-publisher-it alainsahli/confluence-publisher-it:6.0.5; fi
+  - if ( [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] ); then ./waitForConfluenceStartup.sh confluence-publisher-it 300; fi
+  - if ( [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] ); then ./mvnw -Pintegration-tests failsafe:integration-test failsafe:verify -nsu; fi
+  - if ( [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] ); then ./mvnw -pl asciidoc-confluence-publisher-doc asciidoc-confluence-publisher:publish -nsu; fi
+  - if ( [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] ) || [ -n "$TRAVIS_TAG" ]; then ./mvnw -X -s .settings.xml jar:jar source:jar javadoc:jar gpg:sign nexus-staging:deploy -Possrh -nsu; fi
 
 before_cache:
   - rm -rf $HOME/.m2/repository/org/sahli/asciidoc/confluence/publisher


### PR DESCRIPTION
opted for adding if-guard to every script command instead of externalizing commands in separate scripts (e.g. buildPullRequestFromFork.sh vs. build.sh) in order to keep visibility of individual build script steps (and potential failures) in travis log