### PR TITLE
upgrade nexus-staging-maven-plugin to version 1.6.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -303,7 +303,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.7</version>
+                        <version>1.6.8</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>


### PR DESCRIPTION
Based on discussions with the sonatype support, an upgrade to the latest nexus-staging-maven-plugin could solve the broken maven metadata XML issue (see #56)