### PR TITLE
Fix cdata replacements with regular expression symbols

### DIFF
--- a/asciidoc-confluence-publisher-converter/src/main/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePage.java
+++ b/asciidoc-confluence-publisher-converter/src/main/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePage.java
@@ -45,6 +45,7 @@ import static java.nio.file.Files.isDirectory;
 import static java.nio.file.Files.newInputStream;
 import static java.util.Arrays.stream;
 import static java.util.Collections.unmodifiableMap;
+import static java.util.regex.Matcher.quoteReplacement;
 import static java.util.regex.Pattern.DOTALL;
 import static java.util.regex.Pattern.compile;
 import static java.util.stream.Collectors.joining;
@@ -143,7 +144,7 @@ public class AsciidocConfluencePage {
         Matcher matcher = pattern.matcher(content);
 
         while (matcher.find()) {
-            matcher.appendReplacement(replacedContent, replacer.apply(matcher.toMatchResult()));
+            matcher.appendReplacement(replacedContent, quoteReplacement(replacer.apply(matcher.toMatchResult())));
         }
 
         matcher.appendTail(replacedContent);

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -202,6 +202,24 @@ public class AsciidocConfluencePageTest {
     }
 
     @Test
+    public void renderConfluencePage_asciiDocWithSourceListingWithRegularExpressionSymbols_returnsConfluencePageContentWithRegularExpressionSymbolsEscaped() throws Exception {
+        // arrange
+        String adocContent = "[source]\n" +
+                "----\n" +
+                "[0-9][0-9]\\.[0-9][0-9]\\.[0-9]{4}$\n" +
+                "----";
+
+        // act
+        AsciidocConfluencePage asciiDocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+
+        // assert
+        String expectedContent = "<ac:structured-macro ac:name=\"code\">" +
+                "<ac:plain-text-body><![CDATA[[0-9][0-9]\\.[0-9][0-9]\\.[0-9]{4}$]]></ac:plain-text-body>" +
+                "</ac:structured-macro>";
+        assertThat(asciiDocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
     public void renderConfluencePage_asciiDocWithAllPossibleSectionLevels_returnsConfluencePageContentWithAllSectionHavingCorrectMarkup() throws Exception {
         // arrange
         String adocContent = "= Title level 0\n\n" +


### PR DESCRIPTION
The `Matcher.appendReplacement` used in the cdata post-processor by default interprets dollar and backslash signs during replacement. In order to use the replacement as a literal, `Matcher.quoteReplacement` must be used. 

Fixes #85 