### PR TITLE
Encoding configuration support

### DIFF
--- a/asciidoc-confluence-publisher-client/src/main/java/org/sahli/asciidoc/confluence/publisher/client/ConfluencePublisher.java
+++ b/asciidoc-confluence-publisher-client/src/main/java/org/sahli/asciidoc/confluence/publisher/client/ConfluencePublisher.java
@@ -32,6 +32,7 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.codec.digest.DigestUtils.sha256Hex;
@@ -74,7 +75,7 @@ public class ConfluencePublisher {
         deleteConfluencePagesNotPresentUnderAncestor(pages, ancestorId);
 
         pages.forEach(page -> {
-            String content = fileContent(page.getContentFilePath());
+            String content = fileContent(page.getContentFilePath(), UTF_8);
             String contentId = addOrUpdatePage(spaceKey, ancestorId, page, content);
 
             deleteConfluenceAttachmentsNotPresentUnderPage(contentId, page.getAttachments());

--- a/asciidoc-confluence-publisher-client/src/main/java/org/sahli/asciidoc/confluence/publisher/client/http/HttpRequestFactory.java
+++ b/asciidoc-confluence-publisher-client/src/main/java/org/sahli/asciidoc/confluence/publisher/client/http/HttpRequestFactory.java
@@ -46,6 +46,7 @@ import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 import static org.apache.http.entity.ContentType.APPLICATION_OCTET_STREAM;
 import static org.sahli.asciidoc.confluence.publisher.client.http.HttpRequestFactory.PagePayloadBuilder.pagePayloadBuilder;
@@ -283,7 +284,7 @@ class HttpRequestFactory {
     private static BasicHttpEntity httpEntityWithJsonPayload(Object payload) {
         String jsonPayload = toJsonString(payload);
         BasicHttpEntity entity = new BasicHttpEntity();
-        entity.setContent(new ByteArrayInputStream(jsonPayload.getBytes()));
+        entity.setContent(new ByteArrayInputStream(jsonPayload.getBytes(UTF_8)));
 
         return entity;
     }

--- a/asciidoc-confluence-publisher-client/src/main/java/org/sahli/asciidoc/confluence/publisher/client/http/RequestFailedException.java
+++ b/asciidoc-confluence-publisher-client/src/main/java/org/sahli/asciidoc/confluence/publisher/client/http/RequestFailedException.java
@@ -19,6 +19,9 @@ package org.sahli.asciidoc.confluence.publisher.client.http;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 
+import java.io.InputStream;
+import java.nio.charset.Charset;
+
 import static org.sahli.asciidoc.confluence.publisher.client.utils.InputStreamUtils.inputStreamAsString;
 
 /**
@@ -44,7 +47,10 @@ public class RequestFailedException extends RuntimeException {
 
     private static String failedResponseContent(HttpResponse response) {
         try {
-            return inputStreamAsString(response.getEntity().getContent());
+            InputStream content = response.getEntity().getContent();
+            Charset encoding = Charset.forName(response.getEntity().getContentEncoding().getValue());
+
+            return inputStreamAsString(content, encoding);
         } catch (Exception ignored) {
             return "";
         }

--- a/asciidoc-confluence-publisher-client/src/main/java/org/sahli/asciidoc/confluence/publisher/client/utils/InputStreamUtils.java
+++ b/asciidoc-confluence-publisher-client/src/main/java/org/sahli/asciidoc/confluence/publisher/client/utils/InputStreamUtils.java
@@ -22,6 +22,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 import java.util.stream.Collectors;
 
 /**
@@ -33,17 +34,17 @@ public final class InputStreamUtils {
         throw new UnsupportedOperationException("Utils class cannot be instantiated");
     }
 
-    public static String inputStreamAsString(InputStream is) {
-        try (BufferedReader buffer = new BufferedReader(new InputStreamReader(is))) {
+    public static String inputStreamAsString(InputStream is, Charset encoding) {
+        try (BufferedReader buffer = new BufferedReader(new InputStreamReader(is, encoding))) {
             return buffer.lines().collect(Collectors.joining("\n"));
         } catch (IOException e) {
             throw new RuntimeException("Could not convert InputStream to String ", e);
         }
     }
 
-    public static String fileContent(String filePath) {
+    public static String fileContent(String filePath, Charset encoding) {
         try (FileInputStream fileInputStream = new FileInputStream(new File(filePath))) {
-            return inputStreamAsString(fileInputStream);
+            return inputStreamAsString(fileInputStream, encoding);
         } catch (IOException e) {
             throw new RuntimeException("Could not read file", e);
         }

--- a/asciidoc-confluence-publisher-client/src/test/java/org/sahli/asciidoc/confluence/publisher/client/ConfluencePublisherTest.java
+++ b/asciidoc-confluence-publisher-client/src/test/java/org/sahli/asciidoc/confluence/publisher/client/ConfluencePublisherTest.java
@@ -36,6 +36,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.newInputStream;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toMap;
@@ -165,8 +166,8 @@ public class ConfluencePublisherTest {
         verify(confluenceRestClientMock, times(1)).addPageUnderAncestor(eq("~personalSpace"), eq("72189173"), eq("Some Confluence Content"), eq("<h1>Some Confluence Content</h1>"));
         verify(confluenceRestClientMock, times(2)).addAttachment(contentId.capture(), attachmentFileName.capture(), attachmentContent.capture());
         assertThat(contentId.getAllValues(), contains("4321", "4321"));
-        assertThat(inputStreamAsString(attachmentContent.getAllValues().get(attachmentFileName.getAllValues().indexOf("attachmentOne.txt"))), is("attachment1"));
-        assertThat(inputStreamAsString(attachmentContent.getAllValues().get(attachmentFileName.getAllValues().indexOf("attachmentTwo.txt"))), is("attachment2"));
+        assertThat(inputStreamAsString(attachmentContent.getAllValues().get(attachmentFileName.getAllValues().indexOf("attachmentOne.txt")), UTF_8), is("attachment1"));
+        assertThat(inputStreamAsString(attachmentContent.getAllValues().get(attachmentFileName.getAllValues().indexOf("attachmentTwo.txt")), UTF_8), is("attachment2"));
     }
 
     @Test
@@ -242,7 +243,7 @@ public class ConfluencePublisherTest {
         verify(confluenceRestClientMock, never()).addAttachment(anyString(), anyString(), any(InputStream.class));
         ArgumentCaptor<InputStream> attachmentContentCaptor = ArgumentCaptor.forClass(InputStream.class);
         verify(confluenceRestClientMock, times(1)).updateAttachmentContent(eq("3456"), eq("att12"), attachmentContentCaptor.capture());
-        assertThat(inputStreamAsString(attachmentContentCaptor.getValue()), is("attachment1"));
+        assertThat(inputStreamAsString(attachmentContentCaptor.getValue(), UTF_8), is("attachment1"));
     }
 
     @Test

--- a/asciidoc-confluence-publisher-client/src/test/java/org/sahli/asciidoc/confluence/publisher/client/http/ConfluenceRestClientTest.java
+++ b/asciidoc-confluence-publisher-client/src/test/java/org/sahli/asciidoc/confluence/publisher/client/http/ConfluenceRestClientTest.java
@@ -25,6 +25,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.message.BasicHeader;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
@@ -38,6 +39,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.contains;
@@ -240,7 +242,7 @@ public class ConfluenceRestClientTest {
     public void getPageById_withExistingContentId_returnsPageContent() throws Exception {
         // arrange
         String responseFilePath = "src/test/resources/org/sahli/asciidoc/confluence/publisher/client/http/page-content.json";
-        CloseableHttpClient httpClientMock = recordHttpClientForSingleResponseWithContentAndStatusCode(fileContent(responseFilePath), 200);
+        CloseableHttpClient httpClientMock = recordHttpClientForSingleResponseWithContentAndStatusCode(fileContent(responseFilePath, UTF_8), 200);
         ConfluenceRestClient confluenceRestClient = new ConfluenceRestClient(CONFLUENCE_ROOT_URL, httpClientMock, null, null);
 
         // act
@@ -486,7 +488,7 @@ public class ConfluenceRestClientTest {
         InputStream attachmentContent = confluenceRestClient.getAttachmentContent("/download/file.txt?v=2");
 
         // assert
-        assertThat(inputStreamAsString(attachmentContent), is("Attachment content"));
+        assertThat(inputStreamAsString(attachmentContent, UTF_8), is("Attachment content"));
     }
 
     private String generateJsonAttachmentResults(int numberOfAttachment) {
@@ -538,6 +540,7 @@ public class ConfluenceRestClientTest {
         HttpEntity httpEntityMock = mock(HttpEntity.class);
         try {
             when(httpEntityMock.getContent()).thenReturn(new ByteArrayInputStream(content.getBytes()));
+            when(httpEntityMock.getContentEncoding()).thenReturn(new BasicHeader("Content-Encoding", "UTF-8"));
         } catch (IOException e) {
             fail(e.getMessage());
         }

--- a/asciidoc-confluence-publisher-client/src/test/java/org/sahli/asciidoc/confluence/publisher/client/http/HttpRequestFactoryTest.java
+++ b/asciidoc-confluence-publisher-client/src/test/java/org/sahli/asciidoc/confluence/publisher/client/http/HttpRequestFactoryTest.java
@@ -56,12 +56,12 @@ public class HttpRequestFactoryTest {
     private HttpRequestFactory httpRequestFactory;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         this.httpRequestFactory = new HttpRequestFactory(ROOT_CONFLUENCE_URL);
     }
 
     @Test
-    public void instantiation_withEmptyConfluenceRestApiEndpoint_throwsIllegalArgumentException() throws Exception {
+    public void instantiation_withEmptyConfluenceRestApiEndpoint_throwsIllegalArgumentException() {
         // assert
         this.expectedException.expect(IllegalArgumentException.class);
         this.expectedException.expectMessage("rootConfluenceUrl must be set");
@@ -92,7 +92,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void addPageUnderAncestorRequest_withBlankTitle_throwsIllegalArgumentException() throws Exception {
+    public void addPageUnderAncestorRequest_withBlankTitle_throwsIllegalArgumentException() {
         // assert
         this.expectedException.expect(IllegalArgumentException.class);
         this.expectedException.expectMessage("title must be set");
@@ -102,7 +102,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void addPageUnderAncestorRequest_withoutAncestorId_throwsIllegalArgumentException() throws Exception {
+    public void addPageUnderAncestorRequest_withoutAncestorId_throwsIllegalArgumentException() {
         // assert
         this.expectedException.expect(IllegalArgumentException.class);
         this.expectedException.expectMessage("ancestorId must be set");
@@ -134,7 +134,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void updatePageRequest_withEmptyContentId_throwsIllegalArgumentException() throws Exception {
+    public void updatePageRequest_withEmptyContentId_throwsIllegalArgumentException() {
         // assert
         this.expectedException.expect(IllegalArgumentException.class);
         this.expectedException.expectMessage("contentId must be set");
@@ -144,7 +144,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void updatePageRequest_withEmptyAncestorId_throwsIllegalArgumentException() throws Exception {
+    public void updatePageRequest_withEmptyAncestorId_throwsIllegalArgumentException() {
         // assert
         this.expectedException.expect(IllegalArgumentException.class);
         this.expectedException.expectMessage("ancestorId must be set");
@@ -154,7 +154,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void updatePageRequest_withEmptyTitle_throwsIllegalArgumentException() throws Exception {
+    public void updatePageRequest_withEmptyTitle_throwsIllegalArgumentException() {
         // assert
         this.expectedException.expect(IllegalArgumentException.class);
         this.expectedException.expectMessage("title must be set");
@@ -164,7 +164,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void deletePageRequest_withValidParameters_returnsValidHttpDeleteRequest() throws Exception {
+    public void deletePageRequest_withValidParameters_returnsValidHttpDeleteRequest() {
         // arrange
         String contentId = "1234";
 
@@ -177,7 +177,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void deletePageRequest_withEmptyContentId_throwsIllegalArgumentException() throws Exception {
+    public void deletePageRequest_withEmptyContentId_throwsIllegalArgumentException() {
         // assert
         this.expectedException.expect(IllegalArgumentException.class);
         this.expectedException.expectMessage("contentId must be set");
@@ -209,7 +209,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void addAttachmentRequest_withEmptyContentId_throwsIllegalArgumentException() throws Exception {
+    public void addAttachmentRequest_withEmptyContentId_throwsIllegalArgumentException() {
         // assert
         this.expectedException.expect(IllegalArgumentException.class);
         this.expectedException.expectMessage("contentId must be set");
@@ -219,7 +219,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void addAttachmentRequest_withEmptyAttachmentFileName_throwsIllegalArgumentException() throws Exception {
+    public void addAttachmentRequest_withEmptyAttachmentFileName_throwsIllegalArgumentException() {
         // assert
         this.expectedException.expect(IllegalArgumentException.class);
         this.expectedException.expectMessage("attachmentFileName");
@@ -229,7 +229,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void addAttachmentRequest_withNullAttachmentContent_throwsIllegalArgumentException() throws Exception {
+    public void addAttachmentRequest_withNullAttachmentContent_throwsIllegalArgumentException() {
         // assert
         this.expectedException.expect(IllegalArgumentException.class);
         this.expectedException.expectMessage("attachmentContent");
@@ -260,7 +260,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void updateAttachmentContentRequest_withEmptyContentId_throwsIllegalArgumentException() throws Exception {
+    public void updateAttachmentContentRequest_withEmptyContentId_throwsIllegalArgumentException() {
         // assert
         this.expectedException.expect(IllegalArgumentException.class);
         this.expectedException.expectMessage("contentId must be set");
@@ -270,7 +270,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void updateAttachmentContentRequest_withEmptyAttachmentId_throwsIllegalArgumentException() throws Exception {
+    public void updateAttachmentContentRequest_withEmptyAttachmentId_throwsIllegalArgumentException() {
         // assert
         this.expectedException.expect(IllegalArgumentException.class);
         this.expectedException.expectMessage("attachmentId must be set");
@@ -280,7 +280,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void updateAttachmentContentRequest_withNullAttachmentContent_throwsIllegalArgumentException() throws Exception {
+    public void updateAttachmentContentRequest_withNullAttachmentContent_throwsIllegalArgumentException() {
         // assert
         this.expectedException.expect(IllegalArgumentException.class);
         this.expectedException.expectMessage("attachmentContent");
@@ -290,7 +290,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void deleteAttachmentRequest_withValidParameters_returnsValidHttpDelete() throws Exception {
+    public void deleteAttachmentRequest_withValidParameters_returnsValidHttpDelete() {
         // arrange
         String attachmentId = "att1234";
 
@@ -303,7 +303,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void deleteAttachmentRequest_withEmptyAttachmentId_throwsIllegalArgumentException() throws Exception {
+    public void deleteAttachmentRequest_withEmptyAttachmentId_throwsIllegalArgumentException() {
         // assert
         this.expectedException.expect(IllegalArgumentException.class);
         this.expectedException.expectMessage("attachmentId must be set");
@@ -313,7 +313,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void getPageByTitleRequest_withValidParameters_returnsValidHttpGet() throws Exception {
+    public void getPageByTitleRequest_withValidParameters_returnsValidHttpGet() {
         // arrange
         String spaceKey = "~personalSpace";
         String title = "Some page";
@@ -328,7 +328,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void getPageByTitleRequest_withEmptySpaceKey_throwsIllegalArgumentException() throws Exception {
+    public void getPageByTitleRequest_withEmptySpaceKey_throwsIllegalArgumentException() {
         // arrange
         this.expectedException.expect(IllegalArgumentException.class);
         this.expectedException.expectMessage("spaceKey must be set");
@@ -338,7 +338,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void getPageByTitleRequest_withEmptyTitle_throwsIllegalArgumentException() throws Exception {
+    public void getPageByTitleRequest_withEmptyTitle_throwsIllegalArgumentException() {
         // arrange
         this.expectedException.expect(IllegalArgumentException.class);
         this.expectedException.expectMessage("title must be set");
@@ -348,7 +348,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void getAttachmentByFileNameRequest_withMinimalParameters_returnsValidHttpGet() throws Exception {
+    public void getAttachmentByFileNameRequest_withMinimalParameters_returnsValidHttpGet() {
         // arrange
         String contentId = "1234";
         String attachmentFileName = "file.txt";
@@ -361,7 +361,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void getAttachmentByFileNameRequest_withExpandOptions_returnsValidHttpGetWithExpandOptions() throws Exception {
+    public void getAttachmentByFileNameRequest_withExpandOptions_returnsValidHttpGetWithExpandOptions() {
         // arrange
         String contentId = "1234";
         String attachmentFileName = "file.txt";
@@ -376,7 +376,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void getAttachmentByFileNameRequest_withEmptyContentId_throwsIllegalArgumentException() throws Exception {
+    public void getAttachmentByFileNameRequest_withEmptyContentId_throwsIllegalArgumentException() {
         // assert
         this.expectedException.expect(IllegalArgumentException.class);
         this.expectedException.expectMessage("contentId must be set");
@@ -386,7 +386,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void getAttachmentByFileNameRequest_withEmptyAttachmentFileName_throwsIllegalArgumentException() throws Exception {
+    public void getAttachmentByFileNameRequest_withEmptyAttachmentFileName_throwsIllegalArgumentException() {
         // assert
         this.expectedException.expect(IllegalArgumentException.class);
         this.expectedException.expectMessage("attachmentFileName must be set");
@@ -396,7 +396,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void getPageByIdRequest_withValidParameter_returnsValidHttpGet() throws Exception {
+    public void getPageByIdRequest_withValidParameter_returnsValidHttpGet() {
         // arrange
         String contentId = "1234";
 
@@ -408,7 +408,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void getChildPagesByIdRequest_withMinimalParameters_returnsValidHttpGet() throws Exception {
+    public void getChildPagesByIdRequest_withMinimalParameters_returnsValidHttpGet() {
         // arrange
         String parentContentId = "1234";
 
@@ -420,7 +420,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void getChildPagesByIdRequest_withBlankParentContentId_throwsIllegalArgumentException() throws Exception {
+    public void getChildPagesByIdRequest_withBlankParentContentId_throwsIllegalArgumentException() {
         // assert
         this.expectedException.expect(IllegalArgumentException.class);
         this.expectedException.expectMessage("parentContentId must be set");
@@ -430,7 +430,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void getChildPagesByIdRequest_withLimit_returnsHttpGetWithLimit() throws Exception {
+    public void getChildPagesByIdRequest_withLimit_returnsHttpGetWithLimit() {
         // arrange
         String parentContentId = "1234";
         int limit = 5;
@@ -443,7 +443,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void getChildPagesByIdRequest_withPageNumber_returnsHttpGetWithLimit() throws Exception {
+    public void getChildPagesByIdRequest_withPageNumber_returnsHttpGetWithLimit() {
         // arrange
         String parentContentId = "1234";
         int start = 5;
@@ -456,7 +456,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void getChildPagesByIdRequest_withExpandOptions_returnsHttpGetWithExpandOption() throws Exception {
+    public void getChildPagesByIdRequest_withExpandOptions_returnsHttpGetWithExpandOption() {
         // arrange
         String parentContentId = "1234";
         String expandOptions = "version";
@@ -469,7 +469,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void getChildPagesByIdRequest_withLimitAndPageNumber_returnsHttpGetWithPageNumberAndLimit() throws Exception {
+    public void getChildPagesByIdRequest_withLimitAndPageNumber_returnsHttpGetWithPageNumberAndLimit() {
         // arrange
         String parentContentId = "1234";
         int limit = 10;
@@ -484,7 +484,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void getAttachmentsRequest_withMinimalParameters_returnsValidHttpGetRequest() throws Exception {
+    public void getAttachmentsRequest_withMinimalParameters_returnsValidHttpGetRequest() {
         // arrange
         String contentId = "1234";
 
@@ -496,7 +496,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void getAttachmentsRequest_withLimit_returnsHttpGetWithLimit() throws Exception {
+    public void getAttachmentsRequest_withLimit_returnsHttpGetWithLimit() {
         // arrange
         String contentId = "1234";
         int limit = 5;
@@ -509,7 +509,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void getAttachmentsRequest_withPageNumber_returnsHttpGetWithPage() throws Exception {
+    public void getAttachmentsRequest_withPageNumber_returnsHttpGetWithPage() {
         // arrange
         String contentId = "1234";
         int start = 1;
@@ -522,7 +522,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void getAttachmentsRequest_withLimitAndPageNumberAndExpandOptions_returnsHttpGetWithLimitAndPage() throws Exception {
+    public void getAttachmentsRequest_withLimitAndPageNumberAndExpandOptions_returnsHttpGetWithLimitAndPage() {
         // arrange
         String contentId = "1234";
         int limit = 5;
@@ -539,7 +539,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void getAttachmentContentRequest_withValidParameters_returnsHttpGetRequest() throws Exception {
+    public void getAttachmentContentRequest_withValidParameters_returnsHttpGetRequest() {
         // arrange
         String relativeDownloadLink = "/download/attachment.txt";
 
@@ -551,7 +551,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void getAttachmentContentRequest_withBlankRelativeDownloadLink_throwsIllegalArgumentException() throws Exception {
+    public void getAttachmentContentRequest_withBlankRelativeDownloadLink_throwsIllegalArgumentException() {
         // assert
         this.expectedException.expect(IllegalArgumentException.class);
         this.expectedException.expectMessage("relativeDownloadLink must be set");
@@ -593,7 +593,7 @@ public class HttpRequestFactoryTest {
     }
 
     @Test
-    public void deletePropertyByKeyRequest_withValidParameters_returnsHttpDeleteRequest() throws Exception {
+    public void deletePropertyByKeyRequest_withValidParameters_returnsHttpDeleteRequest() {
         // arrange
         String contentId = "1234";
         String key = "content-hash";

--- a/asciidoc-confluence-publisher-client/src/test/java/org/sahli/asciidoc/confluence/publisher/client/http/HttpRequestFactoryTest.java
+++ b/asciidoc-confluence-publisher-client/src/test/java/org/sahli/asciidoc/confluence/publisher/client/http/HttpRequestFactoryTest.java
@@ -30,6 +30,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.nio.file.Paths;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -85,8 +86,8 @@ public class HttpRequestFactoryTest {
         assertThat(addPageUnderAncestorRequest.getURI().toString(), is(CONFLUENCE_REST_API_ENDPOINT + "/content"));
         assertThat(addPageUnderAncestorRequest.getFirstHeader("Content-Type").getValue(), is(APPLICATION_JSON_UTF8));
 
-        String jsonPayload = inputStreamAsString(addPageUnderAncestorRequest.getEntity().getContent());
-        String expectedJsonPayload = fileContent(Paths.get(CLASS_LOCATION, "add-page-request-ancestor-id.json").toString());
+        String jsonPayload = inputStreamAsString(addPageUnderAncestorRequest.getEntity().getContent(), UTF_8);
+        String expectedJsonPayload = fileContent(Paths.get(CLASS_LOCATION, "add-page-request-ancestor-id.json").toString(), UTF_8);
         assertThat(jsonPayload, isSameJsonAs(expectedJsonPayload));
     }
 
@@ -127,8 +128,8 @@ public class HttpRequestFactoryTest {
         assertThat(updatePageRequest.getURI().toString(), is(CONFLUENCE_REST_API_ENDPOINT + "/content/" + contentId));
         assertThat(updatePageRequest.getFirstHeader("Content-Type").getValue(), is(APPLICATION_JSON_UTF8));
 
-        String jsonPayload = inputStreamAsString(updatePageRequest.getEntity().getContent());
-        String expectedJsonPayload = fileContent(Paths.get(CLASS_LOCATION, "update-page-request.json").toString());
+        String jsonPayload = inputStreamAsString(updatePageRequest.getEntity().getContent(), UTF_8);
+        String expectedJsonPayload = fileContent(Paths.get(CLASS_LOCATION, "update-page-request.json").toString(), UTF_8);
         assertThat(jsonPayload, isSameJsonAs(expectedJsonPayload));
     }
 
@@ -573,8 +574,8 @@ public class HttpRequestFactoryTest {
         assertThat(setPropertyByKeyRequest.getURI().toString(), is(CONFLUENCE_REST_API_ENDPOINT + "/content/" + contentId + "/property"));
         assertThat(setPropertyByKeyRequest.getFirstHeader("Content-Type").getValue(), is(APPLICATION_JSON_UTF8));
 
-        String jsonPayload = inputStreamAsString(setPropertyByKeyRequest.getEntity().getContent());
-        String expectedJsonPayload = fileContent(Paths.get(CLASS_LOCATION, "set-property-by-key-request-payload.json").toString());
+        String jsonPayload = inputStreamAsString(setPropertyByKeyRequest.getEntity().getContent(), UTF_8);
+        String expectedJsonPayload = fileContent(Paths.get(CLASS_LOCATION, "set-property-by-key-request-payload.json").toString(), UTF_8);
         assertThat(jsonPayload, isSameJsonAs(expectedJsonPayload));
     }
 

--- a/asciidoc-confluence-publisher-converter/src/main/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluenceConverter.java
+++ b/asciidoc-confluence-publisher-converter/src/main/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluenceConverter.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.nio.file.FileSystem;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -77,7 +78,8 @@ public final class AsciidocConfluenceConverter {
 
             AsciidocPagesStructureProvider.AsciidocPagesStructure structure = asciidocPagesStructureProvider.structure();
             List<AsciidocPage> asciidocPages = structure.pages();
-            List<ConfluencePageMetadata> confluencePages = buildPageTree(templatesRootFolder, assetsRootFolder, asciidocPages, pageTitlePostProcessor);
+            Charset sourceEncoding = asciidocPagesStructureProvider.sourceEncoding();
+            List<ConfluencePageMetadata> confluencePages = buildPageTree(templatesRootFolder, assetsRootFolder, asciidocPages, sourceEncoding, pageTitlePostProcessor);
 
             ConfluencePublisherMetadata confluencePublisherMetadata = new ConfluencePublisherMetadata();
             confluencePublisherMetadata.setSpaceKey(this.spaceKey);
@@ -90,7 +92,7 @@ public final class AsciidocConfluenceConverter {
         }
     }
 
-    private static List<ConfluencePageMetadata> buildPageTree(Path templatesRootFolder, Path assetsRootFolder, List<AsciidocPage> asciidocPages, PageTitlePostProcessor pageTitlePostProcessor) {
+    private static List<ConfluencePageMetadata> buildPageTree(Path templatesRootFolder, Path assetsRootFolder, List<AsciidocPage> asciidocPages, Charset sourceEncoding, PageTitlePostProcessor pageTitlePostProcessor) {
         List<ConfluencePageMetadata> confluencePages = new ArrayList<>();
 
         asciidocPages.forEach((asciidocPage) -> {
@@ -98,13 +100,13 @@ public final class AsciidocConfluenceConverter {
                 Path pageAssetsFolder = determinePageAssetsFolder(assetsRootFolder, asciidocPage);
                 createDirectories(pageAssetsFolder);
 
-                AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, templatesRootFolder, pageAssetsFolder, pageTitlePostProcessor);
+                AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, sourceEncoding, templatesRootFolder, pageAssetsFolder, pageTitlePostProcessor);
                 Path contentFileTargetPath = writeToTargetStructure(asciidocPage, pageAssetsFolder, asciidocConfluencePage);
 
                 List<AttachmentMetadata> attachments = buildAttachments(asciidocPage, pageAssetsFolder, asciidocConfluencePage.attachments());
                 copyAttachmentsAvailableInSourceStructureToTargetStructure(attachments);
 
-                List<ConfluencePageMetadata> childConfluencePages = buildPageTree(templatesRootFolder, assetsRootFolder, asciidocPage.children(), pageTitlePostProcessor);
+                List<ConfluencePageMetadata> childConfluencePages = buildPageTree(templatesRootFolder, assetsRootFolder, asciidocPage.children(), sourceEncoding, pageTitlePostProcessor);
                 ConfluencePageMetadata confluencePageMetadata = buildConfluencePageMetadata(asciidocConfluencePage, contentFileTargetPath, childConfluencePages, attachments);
 
                 confluencePages.add(confluencePageMetadata);

--- a/asciidoc-confluence-publisher-converter/src/main/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluenceConverter.java
+++ b/asciidoc-confluence-publisher-converter/src/main/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluenceConverter.java
@@ -215,7 +215,7 @@ public final class AsciidocConfluenceConverter {
     }
 
     private static void withTemplatesFromFileSystem(URI templatePathUri, Consumer<Path> templateConsumer) throws IOException {
-        list(Paths.get(templatePathUri)).forEach((template) -> templateConsumer.accept(template));
+        list(Paths.get(templatePathUri)).forEach(templateConsumer);
     }
 
     private static void withTemplatesFromJar(URI templatePathUri, Consumer<Path> templateConsumer) throws IOException {
@@ -223,7 +223,7 @@ public final class AsciidocConfluenceConverter {
 
         try (FileSystem jarFileSystem = newFileSystem(jarFileUri, emptyMap())) {
             Path templateRootFolder = jarFileSystem.getPath("/" + TEMPLATE_ROOT_CLASS_PATH_LOCATION);
-            list(templateRootFolder).forEach((template) -> templateConsumer.accept(template));
+            list(templateRootFolder).forEach(templateConsumer);
         }
     }
 

--- a/asciidoc-confluence-publisher-converter/src/main/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocPagesStructureProvider.java
+++ b/asciidoc-confluence-publisher-converter/src/main/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocPagesStructureProvider.java
@@ -16,12 +16,15 @@
 
 package org.sahli.asciidoc.confluence.publisher.converter;
 
+import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.List;
 
 public interface AsciidocPagesStructureProvider {
 
     AsciidocPagesStructure structure();
+
+    Charset sourceEncoding();
 
 
     interface AsciidocPagesStructure {

--- a/asciidoc-confluence-publisher-converter/src/main/java/org/sahli/asciidoc/confluence/publisher/converter/FolderBasedAsciidocPagesStructureProvider.java
+++ b/asciidoc-confluence-publisher-converter/src/main/java/org/sahli/asciidoc/confluence/publisher/converter/FolderBasedAsciidocPagesStructureProvider.java
@@ -17,6 +17,7 @@
 package org.sahli.asciidoc.confluence.publisher.converter;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -34,14 +35,21 @@ public class FolderBasedAsciidocPagesStructureProvider implements AsciidocPagesS
     private static final String INCLUDE_FILE_PREFIX = "_";
 
     private final AsciidocPagesStructure structure;
+    private final Charset sourceEncoding;
 
-    public FolderBasedAsciidocPagesStructureProvider(Path documentationRootFolder) {
+    public FolderBasedAsciidocPagesStructureProvider(Path documentationRootFolder, Charset sourceEncoding) {
         this.structure = buildStructure(documentationRootFolder);
+        this.sourceEncoding = sourceEncoding;
     }
 
     @Override
     public AsciidocPagesStructure structure() {
         return this.structure;
+    }
+
+    @Override
+    public Charset sourceEncoding() {
+        return this.sourceEncoding;
     }
 
     private AsciidocPagesStructure buildStructure(Path documentationRootFolder) {

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluenceConverterTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluenceConverterTest.java
@@ -25,6 +25,7 @@ import org.sahli.asciidoc.confluence.publisher.client.metadata.ConfluencePublish
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.exists;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -47,7 +48,7 @@ public class AsciidocConfluenceConverterTest {
         Path documentationRootFolder = Paths.get(DOCUMENTATION_LOCATION).toAbsolutePath();
         Path buildFolder = this.temporaryFolder.newFolder().toPath().toAbsolutePath();
 
-        AsciidocPagesStructureProvider asciidocPagesStructureProvider = new FolderBasedAsciidocPagesStructureProvider(documentationRootFolder);
+        AsciidocPagesStructureProvider asciidocPagesStructureProvider = new FolderBasedAsciidocPagesStructureProvider(documentationRootFolder, UTF_8);
 
         // act
         AsciidocConfluenceConverter asciidocConfluenceConverter = new AsciidocConfluenceConverter("~personalSpace", "1234");
@@ -86,7 +87,7 @@ public class AsciidocConfluenceConverterTest {
         Path documentationRootFolder = Paths.get(DOCUMENTATION_LOCATION).toAbsolutePath();
         Path buildFolder = this.temporaryFolder.newFolder().toPath().toAbsolutePath();
 
-        AsciidocPagesStructureProvider asciidocPagesStructureProvider = new FolderBasedAsciidocPagesStructureProvider(documentationRootFolder);
+        AsciidocPagesStructureProvider asciidocPagesStructureProvider = new FolderBasedAsciidocPagesStructureProvider(documentationRootFolder, UTF_8);
         PageTitlePostProcessor pageTitlePostProcessor = new PrefixAndSuffixPageTitlePostProcessor("(Doc) ", " (1.0)");
 
         // act
@@ -108,7 +109,7 @@ public class AsciidocConfluenceConverterTest {
         Path documentationRootFolder = this.temporaryFolder.newFolder().toPath().toAbsolutePath();
         Path buildFolder = this.temporaryFolder.newFolder().toPath().toAbsolutePath();
 
-        AsciidocPagesStructureProvider asciidocPagesStructureProvider = new FolderBasedAsciidocPagesStructureProvider(documentationRootFolder);
+        AsciidocPagesStructureProvider asciidocPagesStructureProvider = new FolderBasedAsciidocPagesStructureProvider(documentationRootFolder, UTF_8);
         AsciidocConfluenceConverter asciidocConfluenceConverter = new AsciidocConfluenceConverter("~personalSpace", "1234");
 
         // act

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -69,7 +69,7 @@ public class AsciidocConfluencePageTest {
         String adoc = "= Page title";
 
         // act
-        AsciidocConfluencePage asciiDocConfluencePage = newAsciidocConfluencePage(asciidocPage(adoc), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciiDocConfluencePage = newAsciidocConfluencePage(asciidocPage(adoc), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         assertThat(asciiDocConfluencePage.pageTitle(), is("Page title"));
@@ -81,7 +81,7 @@ public class AsciidocConfluencePageTest {
         String adoc = "= Page title";
 
         // act
-        AsciidocConfluencePage asciiDocConfluencePage = newAsciidocConfluencePage(asciidocPage(adoc), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciiDocConfluencePage = newAsciidocConfluencePage(asciidocPage(adoc), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         assertThat(asciiDocConfluencePage.pageTitle(), is("Page title"));
@@ -94,7 +94,7 @@ public class AsciidocConfluencePageTest {
                 "= Page Title (header)";
 
         // act
-        AsciidocConfluencePage asciiDocConfluencePage = newAsciidocConfluencePage(asciidocPage(adoc), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciiDocConfluencePage = newAsciidocConfluencePage(asciidocPage(adoc), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         assertThat(asciiDocConfluencePage.pageTitle(), is("Page title (meta)"));
@@ -110,7 +110,7 @@ public class AsciidocConfluencePageTest {
         when(pageTitlePostProcessor.process("Page title (meta)")).thenReturn("Post-Processed Page Title");
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(adoc), TEMPLATES_FOLDER, dummyAssetsTargetPath(), pageTitlePostProcessor);
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(adoc), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath(), pageTitlePostProcessor);
 
         // assert
         assertThat(asciidocConfluencePage.pageTitle(), is("Post-Processed Page Title"));
@@ -124,7 +124,7 @@ public class AsciidocConfluencePageTest {
         when(pageTitlePostProcessor.process("Page Title")).thenReturn("Post-Processed Page Title");
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(adoc), TEMPLATES_FOLDER, dummyAssetsTargetPath(), pageTitlePostProcessor);
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(adoc), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath(), pageTitlePostProcessor);
 
         // assert
         assertThat(asciidocConfluencePage.pageTitle(), is("Post-Processed Page Title"));
@@ -140,7 +140,7 @@ public class AsciidocConfluencePageTest {
         this.expectedException.expectMessage("top-level heading or title meta information must be set");
 
         // act
-        newAsciidocConfluencePage(asciidocPage(adoc), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        newAsciidocConfluencePage(asciidocPage(adoc), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
     }
 
     @Test
@@ -151,7 +151,7 @@ public class AsciidocConfluencePageTest {
                 "----";
 
         // act
-        AsciidocConfluencePage asciiDocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciiDocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<ac:structured-macro ac:name=\"noformat\">" +
@@ -169,7 +169,7 @@ public class AsciidocConfluencePageTest {
                 "----";
 
         // act
-        AsciidocConfluencePage asciiDocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciiDocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<ac:structured-macro ac:name=\"code\">" +
@@ -187,7 +187,7 @@ public class AsciidocConfluencePageTest {
                 "----";
 
         // act
-        AsciidocConfluencePage asciiDocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciiDocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<ac:structured-macro ac:name=\"code\">" +
@@ -206,7 +206,7 @@ public class AsciidocConfluencePageTest {
                 "----";
 
         // act
-        AsciidocConfluencePage asciiDocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciiDocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<ac:structured-macro ac:name=\"noformat\">" +
@@ -224,7 +224,7 @@ public class AsciidocConfluencePageTest {
                 "----";
 
         // act
-        AsciidocConfluencePage asciiDocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciiDocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<ac:structured-macro ac:name=\"code\">" +
@@ -242,7 +242,7 @@ public class AsciidocConfluencePageTest {
                 "----";
 
         // act
-        AsciidocConfluencePage asciiDocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciiDocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<ac:structured-macro ac:name=\"code\">" +
@@ -262,7 +262,7 @@ public class AsciidocConfluencePageTest {
                 "====== Title level 5";
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<h1>Title level 1</h1>" +
@@ -279,7 +279,7 @@ public class AsciidocConfluencePageTest {
         String adoc = "some paragraph";
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adoc)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adoc)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<p>some paragraph</p>";
@@ -292,7 +292,7 @@ public class AsciidocConfluencePageTest {
         String adocContent = "*Bold phrase.* bold le**t**ter.";
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<p><strong>Bold phrase.</strong> bold le<strong>t</strong>ter.</p>";
@@ -305,7 +305,7 @@ public class AsciidocConfluencePageTest {
         String adocContent = "a +\nb +\nc";
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<p>a<br/>\nb<br/>\nc</p>";
@@ -318,7 +318,7 @@ public class AsciidocConfluencePageTest {
         String adocContent = "_Italic phrase_ italic le__t__ter.";
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<p><em>Italic phrase</em> italic le<em>t</em>ter.</p>";
@@ -331,7 +331,7 @@ public class AsciidocConfluencePageTest {
         String adocContent = "image::sunset.jpg[Sunset, 300, 200, link=\"http://www.foo.ch\"]";
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<a href=\"http://www.foo.ch\"><ac:image ac:height=\"200\" ac:width=\"300\"><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image></a>";
@@ -344,7 +344,7 @@ public class AsciidocConfluencePageTest {
         String adocContent = "image::sunset.jpg[]";
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<ac:image><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image>";
@@ -357,7 +357,7 @@ public class AsciidocConfluencePageTest {
         String adocContent = "image::sub-folder/sunset.jpg[]";
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<ac:image><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image>";
@@ -384,7 +384,7 @@ public class AsciidocConfluencePageTest {
                 "|===";
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<table><tbody><tr><td>A</td><td>B</td><td>C</td></tr><tr><td>10</td><td>11</td><td>12</td></tr><tr><td>20</td><td>21</td><td>22</td></tr></tbody></table>";
@@ -411,7 +411,7 @@ public class AsciidocConfluencePageTest {
                 "|===";
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<table><thead><tr><th>A</th><th>B</th><th>C</th></tr></thead><tbody><tr><td>10</td><td>11</td><td>12</td></tr><tr><td>20</td><td>21</td><td>22</td></tr></tbody></table>";
@@ -437,7 +437,7 @@ public class AsciidocConfluencePageTest {
         AsciidocPage asciidocPage = asciidocPage(prependTitle(adocContent));
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPage));
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPage));
 
         // assert
         String expectedContent = "<table><thead><tr><th>A</th><th>B</th><th>C</th></tr></thead><tbody><tr><td rowspan=\"2\">10</td><td>11</td><td>12</td></tr><tr><td>13</td><td>14</td></tr></tbody></table>";
@@ -461,7 +461,7 @@ public class AsciidocConfluencePageTest {
         AsciidocPage asciidocPage = asciidocPage(prependTitle(adocContent));
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPage));
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPage));
 
         // assert
         String expectedContent = "<table><thead><tr><th>A</th><th>B</th><th>C</th></tr></thead><tbody><tr><td>10</td><td colspan=\"2\">11 &amp; 12</td></tr></tbody></table>";
@@ -477,7 +477,7 @@ public class AsciidocConfluencePageTest {
                 "====";
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<ac:structured-macro ac:name=\"info\">" +
@@ -496,7 +496,7 @@ public class AsciidocConfluencePageTest {
                 "====";
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<ac:structured-macro ac:name=\"info\">" +
@@ -515,7 +515,7 @@ public class AsciidocConfluencePageTest {
                 "====";
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<ac:structured-macro ac:name=\"tip\">" +
@@ -534,7 +534,7 @@ public class AsciidocConfluencePageTest {
                 "====";
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<ac:structured-macro ac:name=\"tip\">" +
@@ -553,7 +553,7 @@ public class AsciidocConfluencePageTest {
                 "====";
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<ac:structured-macro ac:name=\"note\">" +
@@ -572,7 +572,7 @@ public class AsciidocConfluencePageTest {
                 "====";
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<ac:structured-macro ac:name=\"note\">" +
@@ -591,7 +591,7 @@ public class AsciidocConfluencePageTest {
                 "====";
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<ac:structured-macro ac:name=\"note\">" +
@@ -610,7 +610,7 @@ public class AsciidocConfluencePageTest {
                 "====";
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<ac:structured-macro ac:name=\"note\">" +
@@ -629,7 +629,7 @@ public class AsciidocConfluencePageTest {
                 "====";
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<ac:structured-macro ac:name=\"warning\">" +
@@ -648,7 +648,7 @@ public class AsciidocConfluencePageTest {
                 "====";
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<ac:structured-macro ac:name=\"warning\">" +
@@ -665,7 +665,7 @@ public class AsciidocConfluencePageTest {
         AsciidocPage asciidocPage = asciidocPage(rootFolder, "source-page.adoc");
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPage));
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPage));
 
         // assert
         String expectedContent = "<p>This is a <ac:link><ri:page ri:content-title=\"Target Page\"></ri:page>" +
@@ -681,8 +681,8 @@ public class AsciidocConfluencePageTest {
         AsciidocPage asciidocPageTwo = asciidocPage(Paths.get("src/test/resources/circular-inter-document-cross-references/page-two.adoc"));
 
         // act
-        AsciidocConfluencePage asciidocConfluencePageOne = newAsciidocConfluencePage(asciidocPageOne, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPageOne));
-        AsciidocConfluencePage asciidocConfluencePageTwo = newAsciidocConfluencePage(asciidocPageTwo, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPageTwo));
+        AsciidocConfluencePage asciidocConfluencePageOne = newAsciidocConfluencePage(asciidocPageOne, UTF_8, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPageOne));
+        AsciidocConfluencePage asciidocConfluencePageTwo = newAsciidocConfluencePage(asciidocPageTwo, UTF_8, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPageTwo));
 
         // assert
         assertThat(asciidocConfluencePageOne.content(), containsString("<ri:page ri:content-title=\"Page Two\">"));
@@ -696,7 +696,7 @@ public class AsciidocConfluencePageTest {
         AsciidocPage asciidocPage = asciidocPage(prependTitle(adocContent));
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<p><ac:link><ri:attachment ri:filename=\"foo.txt\"></ri:attachment></ac:link></p>";
@@ -710,7 +710,7 @@ public class AsciidocConfluencePageTest {
         AsciidocPage asciidocPage = asciidocPage(prependTitle(adocContent));
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<p><ac:link><ri:attachment ri:filename=\"foo.txt\"></ri:attachment><ac:plain-text-link-body><![CDATA[Bar]]></ac:plain-text-link-body></ac:link></p>";
@@ -724,7 +724,7 @@ public class AsciidocConfluencePageTest {
         AsciidocPage asciidocPage = asciidocPage(rootFolder, "page.adoc");
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPage));
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPage));
 
         // assert
         assertThat(asciidocConfluencePage.content(), containsString("<p>main content</p>"));
@@ -741,7 +741,7 @@ public class AsciidocConfluencePageTest {
             AsciidocPage asciidocPage = asciidocPage(adocContent);
 
             // act
-            AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPage));
+            AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPage));
 
             // assert
             assertThat(asciidocConfluencePage.pageTitle(), is("Title © !"));
@@ -760,7 +760,7 @@ public class AsciidocConfluencePageTest {
             AsciidocPage asciidocPage = asciidocPage(prependTitle(adocContent));
 
             // act
-            AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPage));
+            AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPage));
 
             // assert
             assertThat(asciidocConfluencePage.content(), is("<p>Copyrighted content © !</p>"));
@@ -770,13 +770,25 @@ public class AsciidocConfluencePageTest {
     }
 
     @Test
+    public void renderConfluencePage_asciiDocWithIsoEncodingAndSpecificSourceEncodingConfigured_returnsConfluencePageWithCorrectlyEncodedContent() {
+        // arrange
+        AsciidocPage asciidocPage = asciidocPage(Paths.get("src/test/resources/encoding/iso-encoded-source.adoc"));
+
+        // act
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, ISO_8859_1, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPage));
+
+        // assert
+        assertThat(asciidocConfluencePage.content(), is("<p>This line contains an ISO-8859-1 encoded special character 'À'.</p>"));
+    }
+
+    @Test
     public void renderConfluencePage_asciiDocWithLinkToAttachmentInDifferentFolder_returnsConfluencePageWithLinkToAttachmentFileNameOnly() {
         // arrange
         String adocContent = "link:bar/foo.txt[]";
         AsciidocPage asciidocPage = asciidocPage(prependTitle(adocContent));
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<p><ac:link><ri:attachment ri:filename=\"foo.txt\"></ri:attachment></ac:link></p>";
@@ -790,7 +802,7 @@ public class AsciidocConfluencePageTest {
         AsciidocPage asciidocPage = asciidocPage(prependTitle(adocContent));
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<p><a href=\"http://www.google.com\">Google</a></p>";
@@ -804,7 +816,7 @@ public class AsciidocConfluencePageTest {
         AsciidocPage asciidocPage = asciidocPage(prependTitle(adocContent));
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<p><a href=\"http://www.google.com\">http://www.google.com</a></p>";
@@ -818,7 +830,7 @@ public class AsciidocConfluencePageTest {
         AsciidocPage asciidocPage = asciidocPage(prependTitle(adocContent));
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<p><a href=\"http://www.google.com\">http://www.google.com</a></p>";
@@ -836,7 +848,7 @@ public class AsciidocConfluencePageTest {
         AsciidocPage asciidocPage = asciidocPage(prependTitle(adocContent));
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPage));
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPage));
 
         // assert
         String expectedContent = "<ac:image ac:height=\"175\" ac:width=\"57\"><ri:attachment ri:filename=\"embedded-diagram.png\"></ri:attachment></ac:image>";
@@ -851,7 +863,7 @@ public class AsciidocConfluencePageTest {
         AsciidocPage asciidocPage = asciidocPage(rootFolder, "page.adoc");
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPage));
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPage));
 
         // assert
         String expectedContent = "<ac:image ac:height=\"175\" ac:width=\"57\"><ri:attachment ri:filename=\"included-diagram.png\"></ri:attachment></ac:image>";
@@ -870,7 +882,7 @@ public class AsciidocConfluencePageTest {
         AsciidocPage asciidocPage = asciidocPage(prependTitle(adocContent));
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<ul><li>L1-1<ul><li>L2-1<ul><li>L3-1<ul><li>L4-1<ul><li>L5-1</li></ul></li></ul></li></ul></li></ul></li><li>L1-2</li></ul>";
@@ -889,7 +901,7 @@ public class AsciidocConfluencePageTest {
         AsciidocPage asciidocPage = asciidocPage(prependTitle(adocContent));
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<ol><li>L1-1<ol><li>L2-1<ol><li>L3-1<ol><li>L4-1<ol><li>L5-1</li></ol></li></ol></li></ol></li></ol></li><li>L1-2</li></ol>";
@@ -903,7 +915,7 @@ public class AsciidocConfluencePageTest {
         AsciidocPage asciidocPage = asciidocPage(prependTitle(adocContent));
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<p>Some text <ac:image><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image> with inline image</p>";
@@ -916,7 +928,7 @@ public class AsciidocConfluencePageTest {
         String adocContent = "Some text image:sunset.jpg[Sunset, 16, 20, link=\"http://www.foo.ch\"] with inline image";
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<p>Some text <a href=\"http://www.foo.ch\"><ac:image ac:height=\"20\" ac:width=\"16\"><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image></a> with inline image</p>";
@@ -929,7 +941,7 @@ public class AsciidocConfluencePageTest {
         String adocContent = "Some text image:sub-folder/sunset.jpg[] with inline image";
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage(prependTitle(adocContent)), UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         String expectedContent = "<p>Some text <ac:image><ri:attachment ri:filename=\"sunset.jpg\"></ri:attachment></ac:image> with inline image</p>";
@@ -944,7 +956,7 @@ public class AsciidocConfluencePageTest {
         AsciidocPage asciidocPage = asciidocPage(prependTitle(adocContent));
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         assertThat(asciidocConfluencePage.attachments().size(), is(1));
@@ -958,7 +970,7 @@ public class AsciidocConfluencePageTest {
         AsciidocPage asciidocPage = asciidocPage(prependTitle(adocContent));
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         assertThat(asciidocConfluencePage.attachments().size(), is(1));
@@ -975,7 +987,7 @@ public class AsciidocConfluencePageTest {
         AsciidocPage asciidocPage = asciidocPage(adocContent);
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         assertThat(asciidocConfluencePage.attachments().size(), is(2));
@@ -991,7 +1003,7 @@ public class AsciidocConfluencePageTest {
         AsciidocPage asciidocPage = asciidocPage(prependTitle(adocContent));
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         assertThat(asciidocConfluencePage.attachments().size(), is(1));
@@ -1005,7 +1017,7 @@ public class AsciidocConfluencePageTest {
         AsciidocPage asciidocPage = asciidocPage(prependTitle(adocContent));
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         assertThat(asciidocConfluencePage.attachments().size(), is(1));
@@ -1019,7 +1031,7 @@ public class AsciidocConfluencePageTest {
         AsciidocPage asciidocPage = asciidocPage(prependTitle(adocContent));
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         assertThat(asciidocConfluencePage.attachments().size(), is(1));
@@ -1034,7 +1046,7 @@ public class AsciidocConfluencePageTest {
         AsciidocPage asciidocPage = asciidocPage(prependTitle(adocContent));
 
         // act
-        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, TEMPLATES_FOLDER, dummyAssetsTargetPath());
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, dummyAssetsTargetPath());
 
         // assert
         assertThat(asciidocConfluencePage.attachments().size(), is(2));

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/FolderBasedAsciidocPagesStructureProviderTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/FolderBasedAsciidocPagesStructureProviderTest.java
@@ -19,10 +19,13 @@ package org.sahli.asciidoc.confluence.publisher.converter;
 import org.junit.Test;
 import org.sahli.asciidoc.confluence.publisher.converter.AsciidocPagesStructureProvider.AsciidocPage;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
@@ -37,7 +40,7 @@ public class FolderBasedAsciidocPagesStructureProviderTest {
     public void structure_nestedStructure_returnsAsciidocPagesStructureWithAllNonIncludeAdocFiles() throws Exception {
         // arrange
         Path documentationRootFolder = Paths.get("src/test/resources/folder-based-asciidoc-page-structure");
-        FolderBasedAsciidocPagesStructureProvider folderBasedAsciidocSourceStructureProvider = new FolderBasedAsciidocPagesStructureProvider(documentationRootFolder);
+        FolderBasedAsciidocPagesStructureProvider folderBasedAsciidocSourceStructureProvider = new FolderBasedAsciidocPagesStructureProvider(documentationRootFolder, UTF_8);
 
         // act
         AsciidocPagesStructureProvider.AsciidocPagesStructure structure = folderBasedAsciidocSourceStructureProvider.structure();
@@ -60,6 +63,19 @@ public class FolderBasedAsciidocPagesStructureProviderTest {
         AsciidocPage subSubPageOne = asciidocPageByPath(indexPage.children(), documentationRootFolder.resolve("index/sub-page-one/sub-sub-page-one.adoc"));
         assertThat(subSubPageOne, is(not(nullValue())));
         assertThat(subSubPageOne.children().size(), is(0));
+    }
+
+    @Test
+    public void sourceEncoding_sourceEncodingProvided_returnsProvidedSourceEncoding() {
+        // arrange
+        Path documentationRootFolder = Paths.get("src/test/resources/folder-based-asciidoc-page-structure");
+        FolderBasedAsciidocPagesStructureProvider folderBasedAsciidocSourceStructureProvider = new FolderBasedAsciidocPagesStructureProvider(documentationRootFolder, UTF_8);
+
+        // act
+        Charset sourceEncoding = folderBasedAsciidocSourceStructureProvider.sourceEncoding();
+
+        // assert
+        assertThat(sourceEncoding, is(UTF_8));
     }
 
     private AsciidocPage asciidocPageByPath(List<AsciidocPage> asciidocPages, Path asciidocPagePath) {

--- a/asciidoc-confluence-publisher-converter/src/test/resources/encoding/iso-encoded-source.adoc
+++ b/asciidoc-confluence-publisher-converter/src/test/resources/encoding/iso-encoded-source.adoc
@@ -1,0 +1,3 @@
+= ISO Encoded Source
+
+This line contains an ISO-8859-1 encoded special character 'À'.

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index.adoc
@@ -47,9 +47,9 @@ is used to derive the page hierarchy in Confluence.
     +- ...
 ----
 
-AsciiDoc files are expected to be encoded in UTF-8. Resources like images, PlantUML files, other attachment types and
-include files can be placed in any location within the documentation root folder. See
-<<00-index/02-includes.adoc#, Includes>>, <<00-index/06-images.adoc#, Images>> and
+AsciiDoc files are expected to be encoded in UTF-8, unless explicitly configured to a different encoding. Resources like
+images, PlantUML files, other attachment types and include files can be placed in any location within the documentation
+root folder. See <<00-index/02-includes.adoc#, Includes>>, <<00-index/06-images.adoc#, Images>> and
 <<00-index/10-plantuml.adoc#, PlantUML>> for more information about resource file path resolution.
 
 [NOTE]
@@ -74,6 +74,7 @@ The Confluence Publisher is configured with the help of a Maven plugin. A typica
       <version><!-- insert version here --></version>
       <configuration>
         <asciidocRootFolder>etc/docs</asciidocRootFolder>
+        <sourceEncoding>UTF-8<sourceEncoding> <!-- default -->
         <rootConfluenceUrl>http://localhost:8090</rootConfluenceUrl>
         <spaceKey>SPACE</spaceKey>
         <ancestorId>327706</ancestorId>
@@ -92,6 +93,9 @@ The Confluence Publisher is configured with the help of a Maven plugin. A typica
 
 | asciidocRootFolder
 | The documentation root folder with the AsciiDoc file structure.
+
+| sourceEncoding
+| The encoding of the AsciiDoc files (optional, defaults to UTF-8).
 
 | rootConfluenceUrl
 | The root URL of the Confluence instance to publish to.

--- a/asciidoc-confluence-publisher-maven-plugin/src/main/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/AsciidocConfluencePublisherMojo.java
+++ b/asciidoc-confluence-publisher-maven-plugin/src/main/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/AsciidocConfluencePublisherMojo.java
@@ -33,6 +33,7 @@ import org.sahli.asciidoc.confluence.publisher.converter.PageTitlePostProcessor;
 import org.sahli.asciidoc.confluence.publisher.converter.PrefixAndSuffixPageTitlePostProcessor;
 
 import java.io.File;
+import java.nio.charset.Charset;
 
 /**
  * @author Alain Sahli
@@ -68,13 +69,17 @@ public class AsciidocConfluencePublisherMojo extends AbstractMojo {
     @Parameter
     private String pageTitleSuffix;
 
+    @Parameter(defaultValue = "UTF-8")
+    private String sourceEncoding;
+
     @SuppressWarnings("ResultOfMethodCallIgnored")
     @Override
     public void execute() throws MojoExecutionException {
         try {
             PageTitlePostProcessor pageTitlePostProcessor = new PrefixAndSuffixPageTitlePostProcessor(this.pageTitlePrefix, this.pageTitleSuffix);
 
-            AsciidocPagesStructureProvider asciidocPagesStructureProvider = new FolderBasedAsciidocPagesStructureProvider(this.asciidocRootFolder.toPath());
+            AsciidocPagesStructureProvider asciidocPagesStructureProvider = new FolderBasedAsciidocPagesStructureProvider(this.asciidocRootFolder.toPath(), Charset.forName(this.sourceEncoding));
+
             AsciidocConfluenceConverter asciidocConfluenceConverter = new AsciidocConfluenceConverter(this.spaceKey, this.ancestorId);
             ConfluencePublisherMetadata confluencePublisherMetadata = asciidocConfluenceConverter.convert(asciidocPagesStructureProvider, pageTitlePostProcessor, this.confluencePublisherBuildFolder.toPath());
 

--- a/asciidoc-confluence-publisher-maven-plugin/src/main/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/AsciidocConfluencePublisherMojo.java
+++ b/asciidoc-confluence-publisher-maven-plugin/src/main/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/AsciidocConfluencePublisherMojo.java
@@ -48,6 +48,9 @@ public class AsciidocConfluencePublisherMojo extends AbstractMojo {
     @Parameter
     private File asciidocRootFolder;
 
+    @Parameter(defaultValue = "UTF-8")
+    private String sourceEncoding;
+
     @Parameter
     private String rootConfluenceUrl;
 
@@ -68,9 +71,6 @@ public class AsciidocConfluencePublisherMojo extends AbstractMojo {
 
     @Parameter
     private String pageTitleSuffix;
-
-    @Parameter(defaultValue = "UTF-8")
-    private String sourceEncoding;
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
     @Override


### PR DESCRIPTION
- new optional Maven plugin parameter `sourceEncoding` (defaults to UTF-8)

Resolves #94 