### PR TITLE
Support AsciiDoc cell content in table

### DIFF
--- a/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_table.html.slim
+++ b/asciidoc-confluence-publisher-converter/src/main/resources/org/sahli/asciidoc/confluence/publisher/converter/templates/block_table.html.slim
@@ -1,8 +1,25 @@
 table
-  - [:head, :foot, :body].select {|tblsec| !@rows[tblsec].empty? }.each do |tblsec|
-    *{:tag=>"t#{tblsec}"}
-      - @rows[tblsec].each do |row|
-        tr
-          - row.each do |cell|
-            *{:tag => (tblsec == :head ? 'th' : 'td'), rowspan: cell.rowspan, colspan: cell.colspan}
-              =cell.text
+  - if title?
+    caption.title =captioned_title
+  - unless (attr :rowcount).zero?
+    - [:head, :foot, :body].reject { |tblsec| rows[tblsec].empty? }.each do |tblsec|
+      *{tag: %(t#{tblsec})}
+        - rows[tblsec].each do |row|
+          tr
+            - row.each do |cell|
+              *{tag: (tblsec == :head || cell.style == :header ? 'th' : 'td'),
+                  colspan: cell.colspan,
+                  rowspan: cell.rowspan}
+                - if tblsec == :head
+                  =cell.text
+                - else
+                  - case cell.style
+                  - when :asciidoc
+                    div =cell.content
+                  - when :verse
+                    .verse =cell.text
+                  - when :literal
+                    .literal: pre =cell.text
+                  - else
+                    - cell.content.each do |text|
+                      =text

--- a/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
+++ b/asciidoc-confluence-publisher-converter/src/test/java/org/sahli/asciidoc/confluence/publisher/converter/AsciidocConfluencePageTest.java
@@ -469,6 +469,31 @@ public class AsciidocConfluencePageTest {
     }
 
     @Test
+    public void renderConfluencePage_asciiDocWithTableWithAsciiDocCell_returnsConfluencePageWithTableWithAsciiDocCell() {
+        // arrange
+        String adocContent = "" +
+            "|===\n" +
+            "| A " +
+            "| B\n" +
+            "\n" +
+            "| 10 " +
+            "a|11\n" +
+            "\n" +
+            "* 12 \n" +
+            "* 13 \n" +
+            "\n" +
+            "|===";
+        AsciidocPage asciidocPage = asciidocPage(prependTitle(adocContent));
+
+        // act
+        AsciidocConfluencePage asciidocConfluencePage = newAsciidocConfluencePage(asciidocPage, UTF_8, TEMPLATES_FOLDER, assetsTargetFolderFor(asciidocPage));
+
+        // assert
+        String expectedContent = "<table><thead><tr><th>A</th><th>B</th></tr></thead><tbody><tr><td>10</td><td><div><p>11</p>\n<ul><li>12</li><li>13</li></ul></div></td></tr></tbody></table>";
+        assertThat(asciidocConfluencePage.content(), is(expectedContent));
+    }
+
+    @Test
     public void renderConfluencePage_asciiDocWithNoteContent_returnsConfluencePageContentWithInfoMacroWithContent() {
         // arrange
         String adocContent = "[NOTE]\n" +

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index/05-tables.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index/05-tables.adoc
@@ -165,3 +165,30 @@ Currently, only simple formattings, but no nested tables or lists are supported.
 | B1
 | B2
 |===
+
+== Table with asciidoc cell
+
+[listing]
+....
+|===
+| Column 1 | Column 2
+
+|A1 a|A2
+
+* A3
+* A4
+* A5
+
+|===
+....
+
+|===
+| Column 1 | Column 2
+
+|A1 a|A2
+
+* A3
+* A4
+* A5
+
+|===


### PR DESCRIPTION
Update HTML table slim to support AsciiDoc cell content in table. Reference implementation: https://github.com/asciidoctor/asciidoctor-backends/blob/master/slim/html5/block_table.html.slim