### PR TITLE
Implement REPLACE_ANCESTOR publish strategy

### DIFF
--- a/asciidoc-confluence-publisher-cli/src/main/java/org/sahli/asciidoc/confluence/publisher/cli/AsciidocConfluencePublisherCommandLineClient.java
+++ b/asciidoc-confluence-publisher-cli/src/main/java/org/sahli/asciidoc/confluence/publisher/cli/AsciidocConfluencePublisherCommandLineClient.java
@@ -21,6 +21,7 @@ import org.sahli.asciidoc.confluence.publisher.client.ConfluencePublisherListene
 import org.sahli.asciidoc.confluence.publisher.client.http.ConfluencePage;
 import org.sahli.asciidoc.confluence.publisher.client.http.ConfluenceRestClient;
 import org.sahli.asciidoc.confluence.publisher.client.metadata.ConfluencePublisherMetadata;
+import org.sahli.asciidoc.confluence.publisher.client.metadata.ConfluencePublisherPublishStrategy;
 import org.sahli.asciidoc.confluence.publisher.converter.AsciidocConfluenceConverter;
 import org.sahli.asciidoc.confluence.publisher.converter.AsciidocPagesStructureProvider;
 import org.sahli.asciidoc.confluence.publisher.converter.FolderBasedAsciidocPagesStructureProvider;
@@ -51,6 +52,9 @@ public class AsciidocConfluencePublisherCommandLineClient {
         String spaceKey = mandatoryArgument("spaceKey", args);
         String ancestorId = mandatoryArgument("ancestorId", args);
 
+        String publishStrategyParam = optionalArgument("strategy", args).orElse(null);
+        ConfluencePublisherPublishStrategy publishStrategy = publishStrategyParam == null ? ConfluencePublisherPublishStrategy.APPEND_TO_ANCESTOR : ConfluencePublisherPublishStrategy.valueOf(publishStrategyParam);
+
         Path documentationRootFolder = Paths.get(mandatoryArgument("asciidocRootFolder", args));
         Path buildFolder = createTempDirectory("confluence-publisher");
 
@@ -64,6 +68,7 @@ public class AsciidocConfluencePublisherCommandLineClient {
 
             AsciidocConfluenceConverter asciidocConfluenceConverter = new AsciidocConfluenceConverter(spaceKey, ancestorId);
             ConfluencePublisherMetadata confluencePublisherMetadata = asciidocConfluenceConverter.convert(asciidocPagesStructureProvider, pageTitlePostProcessor, buildFolder);
+            confluencePublisherMetadata.setPublishStrategy(publishStrategy);
 
             ConfluenceRestClient confluenceClient = new ConfluenceRestClient(rootConfluenceUrl, username, password);
             ConfluencePublisher confluencePublisher = new ConfluencePublisher(confluencePublisherMetadata, confluenceClient, new SystemOutLoggingConfluencePublisherListener());

--- a/asciidoc-confluence-publisher-client/src/main/java/org/sahli/asciidoc/confluence/publisher/client/http/ConfluencePage.java
+++ b/asciidoc-confluence-publisher-client/src/main/java/org/sahli/asciidoc/confluence/publisher/client/http/ConfluencePage.java
@@ -21,20 +21,26 @@ package org.sahli.asciidoc.confluence.publisher.client.http;
  */
 public class ConfluencePage {
 
+    private final String ancestorId;
     private final String contentId;
     private final String title;
     private final String content;
     private final int version;
 
-    public ConfluencePage(String contentId, String title, int version) {
-        this(contentId, title, null, version);
+    public ConfluencePage(String ancestorId, String contentId, String title, int version) {
+        this(ancestorId, contentId, title, null, version);
     }
 
-    public ConfluencePage(String contentId, String title, String content, int version) {
+    public ConfluencePage(String ancestorId, String contentId, String title, String content, int version) {
+        this.ancestorId = ancestorId;
         this.contentId = contentId;
         this.title = title;
         this.content = content;
         this.version = version;
+    }
+
+    public String getAncestorId() {
+        return this.ancestorId;
     }
 
     public String getContentId() {
@@ -61,6 +67,7 @@ public class ConfluencePage {
         ConfluencePage that = (ConfluencePage) o;
 
         if (this.version != that.version) return false;
+        if (!this.ancestorId.equals(that.ancestorId)) return false;
         if (!this.contentId.equals(that.contentId)) return false;
         //noinspection SimplifiableIfStatement
         if (!this.title.equals(that.title)) return false;
@@ -70,7 +77,8 @@ public class ConfluencePage {
 
     @Override
     public int hashCode() {
-        int result = this.contentId.hashCode();
+        int result = this.ancestorId.hashCode();
+        result = 31 * result + this.contentId.hashCode();
         result = 31 * result + this.title.hashCode();
         result = 31 * result + (this.content != null ? this.content.hashCode() : 0);
         result = 31 * result + this.version;
@@ -80,7 +88,8 @@ public class ConfluencePage {
     @Override
     public String toString() {
         return "ConfluencePage{" +
-                "contentId='" + this.contentId + '\'' +
+                "ancestorId='" + this.ancestorId + '\'' +
+                ", contentId='" + this.contentId + '\'' +
                 ", title='" + this.title + '\'' +
                 ", content='" + this.content + '\'' +
                 ", version=" + this.version +

--- a/asciidoc-confluence-publisher-client/src/main/java/org/sahli/asciidoc/confluence/publisher/client/metadata/ConfluencePublisherMetadata.java
+++ b/asciidoc-confluence-publisher-client/src/main/java/org/sahli/asciidoc/confluence/publisher/client/metadata/ConfluencePublisherMetadata.java
@@ -29,6 +29,7 @@ public class ConfluencePublisherMetadata {
     private String spaceKey;
     private String ancestorId;
     private List<ConfluencePageMetadata> pages = new ArrayList<>();
+    private ConfluencePublisherPublishStrategy publishStrategy = ConfluencePublisherPublishStrategy.APPEND_TO_ANCESTOR;
 
     public String getSpaceKey() {
         return this.spaceKey;
@@ -57,4 +58,12 @@ public class ConfluencePublisherMetadata {
         this.pages = pages;
     }
 
+    public ConfluencePublisherPublishStrategy getPublishStrategy() {
+        return publishStrategy;
+    }
+
+    @RuntimeUse
+    public void setPublishStrategy(ConfluencePublisherPublishStrategy publishStrategy) {
+        this.publishStrategy = publishStrategy;
+    }
 }

--- a/asciidoc-confluence-publisher-client/src/main/java/org/sahli/asciidoc/confluence/publisher/client/metadata/ConfluencePublisherPublishStrategy.java
+++ b/asciidoc-confluence-publisher-client/src/main/java/org/sahli/asciidoc/confluence/publisher/client/metadata/ConfluencePublisherPublishStrategy.java
@@ -1,0 +1,10 @@
+package org.sahli.asciidoc.confluence.publisher.client.metadata;
+
+/**
+ * @author Laurent Verbruggen
+ */
+public enum ConfluencePublisherPublishStrategy {
+
+    APPEND_TO_ANCESTOR,
+    REPLACE_ANCESTOR;
+}

--- a/asciidoc-confluence-publisher-client/src/test/java/org/sahli/asciidoc/confluence/publisher/client/http/ConfluenceRestClientTest.java
+++ b/asciidoc-confluence-publisher-client/src/test/java/org/sahli/asciidoc/confluence/publisher/client/http/ConfluenceRestClientTest.java
@@ -253,6 +253,7 @@ public class ConfluenceRestClientTest {
         assertThat(confluencePage.getTitle(), is("Some title"));
         assertThat(confluencePage.getContent(), is("Some content"));
         assertThat(confluencePage.getVersion(), is(1));
+        assertThat(confluencePage.getAncestorId(), is("3456"));
     }
 
     @Test
@@ -267,8 +268,8 @@ public class ConfluenceRestClientTest {
         List<ConfluencePage> childPages = confluenceRestClient.getChildPages(contentId);
 
         // assert
-        ConfluencePage childOne = new ConfluencePage("1", "Page 1", 1);
-        ConfluencePage childTwo = new ConfluencePage("2", "Page 2", 1);
+        ConfluencePage childOne = new ConfluencePage("ancestor", "1", "Page 1", 1);
+        ConfluencePage childTwo = new ConfluencePage("ancestor", "2", "Page 2", 1);
         assertThat(childPages, Matchers.contains(childOne, childTwo));
     }
 
@@ -563,7 +564,12 @@ public class ConfluenceRestClientTest {
     private static String generateJsonPageResults(int numberOfPages) {
         return IntStream.range(1, numberOfPages + 1)
                 .boxed()
-                .map(pageNumber -> "{\"id\": \"" + pageNumber + "\", \"title\": \"Page " + pageNumber + "\", \"version\": {\"number\": 1}}")
+                .map(pageNumber -> "{" +
+                        "\"id\": \"" + pageNumber + "\", " +
+                        "\"title\": \"Page " + pageNumber + "\", " +
+                        "\"version\": {\"number\": 1}," +
+                        "\"ancestors\": [{\"id\": \"ancestor\"}]" +
+                    "}")
                 .collect(Collectors.joining(",\n"));
     }
 

--- a/asciidoc-confluence-publisher-client/src/test/resources/org/sahli/asciidoc/confluence/publisher/client/http/page-content.json
+++ b/asciidoc-confluence-publisher-client/src/test/resources/org/sahli/asciidoc/confluence/publisher/client/http/page-content.json
@@ -8,5 +8,13 @@
     "storage": {
       "value": "Some content"
     }
-  }
+  },
+  "ancestors": [
+    {
+      "id": "2345"
+    },
+    {
+      "id": "3456"
+    }
+  ]
 }

--- a/asciidoc-confluence-publisher-client/src/test/resources/org/sahli/asciidoc/confluence/publisher/client/metadata-existing-page-ancestor-id-replace.json
+++ b/asciidoc-confluence-publisher-client/src/test/resources/org/sahli/asciidoc/confluence/publisher/client/metadata-existing-page-ancestor-id-replace.json
@@ -1,0 +1,11 @@
+{
+  "spaceKey": "~personalSpace",
+  "ancestorId": "1234",
+  "pages": [
+    {
+      "title": "Existing Page",
+      "contentFilePath": "some-confluence-content.html"
+    }
+  ],
+  "publishStrategy": "REPLACE_ANCESTOR"
+}

--- a/asciidoc-confluence-publisher-client/src/test/resources/org/sahli/asciidoc/confluence/publisher/client/metadata-multiple-page-ancestor-id-replace.json
+++ b/asciidoc-confluence-publisher-client/src/test/resources/org/sahli/asciidoc/confluence/publisher/client/metadata-multiple-page-ancestor-id-replace.json
@@ -1,0 +1,15 @@
+{
+  "spaceKey": "~personalSpace",
+  "ancestorId": "72189173",
+  "pages": [
+    {
+      "title": "Some Confluence Content",
+      "contentFilePath": "some-confluence-content.html"
+    },
+    {
+      "title": "Some Other Confluence Content",
+      "contentFilePath": "some-confluence-content.html"
+    }
+  ],
+  "publishStrategy": "REPLACE_ANCESTOR"
+}

--- a/asciidoc-confluence-publisher-client/src/test/resources/org/sahli/asciidoc/confluence/publisher/client/metadata-multiple-page-ancestor-id.json
+++ b/asciidoc-confluence-publisher-client/src/test/resources/org/sahli/asciidoc/confluence/publisher/client/metadata-multiple-page-ancestor-id.json
@@ -1,0 +1,14 @@
+{
+  "spaceKey": "~personalSpace",
+  "ancestorId": "72189173",
+  "pages": [
+    {
+      "title": "Some Confluence Content",
+      "contentFilePath": "some-confluence-content.html"
+    },
+    {
+      "title": "Some Other Confluence Content",
+      "contentFilePath": "some-confluence-content.html"
+    }
+  ]
+}

--- a/asciidoc-confluence-publisher-client/src/test/resources/org/sahli/asciidoc/confluence/publisher/client/metadata-zero-page-space-key-replace.json
+++ b/asciidoc-confluence-publisher-client/src/test/resources/org/sahli/asciidoc/confluence/publisher/client/metadata-zero-page-space-key-replace.json
@@ -1,0 +1,6 @@
+{
+  "spaceKey": "~personalSpace",
+  "ancestorId": "1234",
+  "pages": [],
+  "publishStrategy": "REPLACE_ANCESTOR"
+}

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index.adoc
@@ -238,6 +238,7 @@ docker run --rm -e ROOT_CONFLUENCE_URL=http://confluence-host \
    -e ANCESTOR_ID=012345 \
    -e PAGE_TITLE_PREFIX="Draft - " \
    -e PAGE_TITLE_SUFFIX=" (V 1.0)" \
+   -e STRATEGY=REPLACE_ANCESTOR \
    -v /absolute/path/to/asciidoc-root-folder:/var/asciidoc-root-folder \
    confluencepublisher/confluence-publisher:0.0.0-SNAPSHOT
 ----

--- a/asciidoc-confluence-publisher-doc/etc/docs/00-index.adoc
+++ b/asciidoc-confluence-publisher-doc/etc/docs/00-index.adoc
@@ -123,6 +123,14 @@ The Confluence Publisher is configured with the help of a Maven plugin. A typica
 | The password of the user to use for publishing.
 | mandatory
 
+| strategy
+| Which strategy to use when publishing to confluence. Possible values:
+
+* `APPEND_TO_ANCESTOR`: append the published pages to the ancestor and clean up all other existing pages under the ancestor
+* `REPLACE_ANCESTOR`: replace the title and the content of the ancestor with those of the root page. It enforces a constraint on the source documentation structure since only a single root page is allowed. Passing more will result in an error. Existing pages under the ancestor will be cleaned up and replaced by the children pages of the single root page.
+
+| optional (defaults to `APPEND_TO_ANCESTOR`)
+
 | pageTitlePrefix
 | The prefix to be prepended to every page title.
 

--- a/asciidoc-confluence-publisher-docker/Dockerfile
+++ b/asciidoc-confluence-publisher-docker/Dockerfile
@@ -13,7 +13,8 @@ ENV SOURCE_ENCODING="" \
     USERNAME=""  \
     PASSWORD=""  \
     PAGE_TITLE_PREFIX=""  \
-    PAGE_TITLE_SUFFIX=""
+    PAGE_TITLE_SUFFIX="" \
+    STRATEGY=""
 
 ENTRYPOINT ["sh", "-c", "java -jar /opt/asciidoc-confluence-publisher-docker.jar \
     \"asciidocRootFolder=/var/asciidoc-root-folder\" \
@@ -25,4 +26,5 @@ ENTRYPOINT ["sh", "-c", "java -jar /opt/asciidoc-confluence-publisher-docker.jar
     \"password=$PASSWORD\" \
     \"pageTitlePrefix=$PAGE_TITLE_PREFIX\" \
     \"pageTitleSuffix=$PAGE_TITLE_SUFFIX\" \
+    \"strategy=$STRATEGY\" \
 "]

--- a/asciidoc-confluence-publisher-maven-plugin/src/main/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/AsciidocConfluencePublisherMojo.java
+++ b/asciidoc-confluence-publisher-maven-plugin/src/main/java/org/sahli/asciidoc/confluence/publisher/maven/plugin/AsciidocConfluencePublisherMojo.java
@@ -26,6 +26,7 @@ import org.sahli.asciidoc.confluence.publisher.client.ConfluencePublisherListene
 import org.sahli.asciidoc.confluence.publisher.client.http.ConfluencePage;
 import org.sahli.asciidoc.confluence.publisher.client.http.ConfluenceRestClient;
 import org.sahli.asciidoc.confluence.publisher.client.metadata.ConfluencePublisherMetadata;
+import org.sahli.asciidoc.confluence.publisher.client.metadata.ConfluencePublisherPublishStrategy;
 import org.sahli.asciidoc.confluence.publisher.converter.AsciidocConfluenceConverter;
 import org.sahli.asciidoc.confluence.publisher.converter.AsciidocPagesStructureProvider;
 import org.sahli.asciidoc.confluence.publisher.converter.FolderBasedAsciidocPagesStructureProvider;
@@ -60,6 +61,9 @@ public class AsciidocConfluencePublisherMojo extends AbstractMojo {
     @Parameter(required = true)
     private String ancestorId;
 
+    @Parameter(defaultValue = "APPEND_TO_ANCESTOR")
+    private ConfluencePublisherPublishStrategy strategy;
+
     @Parameter
     private String username;
 
@@ -82,6 +86,7 @@ public class AsciidocConfluencePublisherMojo extends AbstractMojo {
 
             AsciidocConfluenceConverter asciidocConfluenceConverter = new AsciidocConfluenceConverter(this.spaceKey, this.ancestorId);
             ConfluencePublisherMetadata confluencePublisherMetadata = asciidocConfluenceConverter.convert(asciidocPagesStructureProvider, pageTitlePostProcessor, this.confluencePublisherBuildFolder.toPath());
+            confluencePublisherMetadata.setPublishStrategy(strategy);
 
             ConfluenceRestClient confluenceRestClient = new ConfluenceRestClient(this.rootConfluenceUrl, this.username, this.password);
             ConfluencePublisherListener confluencePublisherListener = new LoggingConfluencePublisherListener(getLog());


### PR DESCRIPTION
In some cases you might want to keep siblings in your ancestor instead of cleaning everything up.
I made the default so that there are no breaking changes.