### PR TITLE
Attachments are not added for root page using REPLACE_ANCESTOR

### DIFF
--- a/asciidoc-confluence-publisher-client/src/it/resources/attachments/attachmentOne.txt
+++ b/asciidoc-confluence-publisher-client/src/it/resources/attachments/attachmentOne.txt
@@ -1,0 +1,1 @@
+attachment1

--- a/asciidoc-confluence-publisher-client/src/it/resources/attachments/attachmentTwo.txt
+++ b/asciidoc-confluence-publisher-client/src/it/resources/attachments/attachmentTwo.txt
@@ -1,0 +1,1 @@
+attachment2

--- a/asciidoc-confluence-publisher-client/src/main/java/org/sahli/asciidoc/confluence/publisher/client/ConfluencePublisher.java
+++ b/asciidoc-confluence-publisher-client/src/main/java/org/sahli/asciidoc/confluence/publisher/client/ConfluencePublisher.java
@@ -80,12 +80,7 @@ public class ConfluencePublisher {
                 startPublishingUnderAncestorId(this.metadata.getPages(), this.metadata.getSpaceKey(), this.metadata.getAncestorId());
                 break;
             case REPLACE_ANCESTOR:
-                ConfluencePageMetadata rootPageMetaData = singleRootPageMetadata(this.metadata);
-
-                if (rootPageMetaData != null) {
-                    updatePage(this.metadata.getAncestorId(), null, rootPageMetaData);
-                    startPublishingUnderAncestorId(rootPageMetaData.getChildren(), this.metadata.getSpaceKey(), this.metadata.getAncestorId());
-                }
+                startPublishingReplacingAncestorId(this.metadata, this.metadata.getSpaceKey(), this.metadata.getAncestorId());
                 break;
             default:
                 throw new IllegalArgumentException("Invalid publishing strategy '" + this.publishingStrategy + "'");
@@ -112,6 +107,19 @@ public class ConfluencePublisher {
         return null;
     }
 
+    private void startPublishingReplacingAncestorId(ConfluencePublisherMetadata metadata, String spaceKey, String ancestorId) {
+        ConfluencePageMetadata rootPage = singleRootPageMetadata(metadata);
+
+        if (rootPage != null) {
+            updatePage(ancestorId, null, rootPage);
+
+            deleteConfluenceAttachmentsNotPresentUnderPage(ancestorId, rootPage.getAttachments());
+            addAttachments(ancestorId, rootPage.getAttachments());
+
+            startPublishingUnderAncestorId(rootPage.getChildren(), spaceKey, ancestorId);
+        }
+    }
+
     private void startPublishingUnderAncestorId(List<ConfluencePageMetadata> pages, String spaceKey, String ancestorId) {
         deleteConfluencePagesNotPresentUnderAncestor(pages, ancestorId);
         pages.forEach(page -> {
@@ -119,6 +127,7 @@ public class ConfluencePublisher {
 
             deleteConfluenceAttachmentsNotPresentUnderPage(contentId, page.getAttachments());
             addAttachments(contentId, page.getAttachments());
+
             startPublishingUnderAncestorId(page.getChildren(), spaceKey, contentId);
         });
     }

--- a/asciidoc-confluence-publisher-client/src/test/java/org/sahli/asciidoc/confluence/publisher/client/ConfluencePublisherTest.java
+++ b/asciidoc-confluence-publisher-client/src/test/java/org/sahli/asciidoc/confluence/publisher/client/ConfluencePublisherTest.java
@@ -283,6 +283,39 @@ public class ConfluencePublisherTest {
     }
 
     @Test
+    public void publish_metadataWithExistingPageAndNewAttachments_sendsUpdateAndAddAttachmentRequests() {
+        // arrange
+        ConfluencePage existingPage = new ConfluencePage("72189173", "Existing Page (Old Title)", "<h1>Some Confluence Content</h1>", 1);
+
+        ConfluenceRestClient confluenceRestClientMock = mock(ConfluenceRestClient.class);
+        when(confluenceRestClientMock.getPageWithContentAndVersionById("72189173")).thenReturn(existingPage);
+        when(confluenceRestClientMock.getPropertyByKey("72189173", CONTENT_HASH_PROPERTY_KEY)).thenReturn(SOME_CONFLUENCE_CONTENT_SHA256_HASH);
+        when(confluenceRestClientMock.getAttachmentByFileName("72189173", "attachmentOne.txt"))
+                .thenThrow(new NotFoundException());
+        when(confluenceRestClientMock.getAttachmentByFileName("72189173", "attachmentTwo.txt"))
+                .thenReturn(new ConfluenceAttachment("att2", "attachmentOne.txt", "/download/attachmentOne.txt", 1));
+        when(confluenceRestClientMock.getAttachmentContent("/download/attachmentOne.txt"))
+                .thenReturn(new ByteArrayInputStream("Old content".getBytes()));
+
+        ConfluencePublisherListener confluencePublisherListenerMock = mock(ConfluencePublisherListener.class);
+
+        ConfluencePublisher confluencePublisher = confluencePublisher("root-ancestor-id-page-with-attachments", REPLACE_ANCESTOR, confluenceRestClientMock, confluencePublisherListenerMock, null);
+
+        // act
+        confluencePublisher.publish();
+
+        // assert
+        verify(confluenceRestClientMock, never()).addPageUnderAncestor(any(), any(), any(), any(), any());
+        verify(confluenceRestClientMock, times(1)).updatePage(eq("72189173"), eq(null), eq("Some Confluence Content"), eq("<h1>Some Confluence Content</h1>"), eq(2), eq(null));
+        verify(confluenceRestClientMock).addAttachment(eq("72189173"), eq("attachmentOne.txt"), any(InputStream.class));
+        verify(confluenceRestClientMock).updateAttachmentContent(eq("72189173"), eq("att2"), any(InputStream.class));
+
+        verify(confluencePublisherListenerMock, times(1)).pageUpdated(existingPage, new ConfluencePage("72189173", "Some Confluence Content", "<h1>Some Confluence Content</h1>", 2));
+        verify(confluencePublisherListenerMock, times(1)).publishCompleted();
+        verifyNoMoreInteractions(confluencePublisherListenerMock);
+    }
+
+    @Test
     public void publish_metadataWithExistingPageAndAttachmentWithDifferentAttachmentContentUnderRootSpace_sendsUpdateAttachmentRequest() {
         // arrange
         ConfluenceRestClient confluenceRestClientMock = mock(ConfluenceRestClient.class);


### PR DESCRIPTION
Attachments are not added for root page when REPLACE_ANCESTOR publishing strategy is used